### PR TITLE
Clean up compile_metadata.dart

### DIFF
--- a/_tests/test/compiler/compile_metadata_test.dart
+++ b/_tests/test/compiler/compile_metadata_test.dart
@@ -1,157 +1,15 @@
 library angular2.test.compiler.compile_metadata_test;
 
 import 'package:test/test.dart';
-import "package:angular/src/compiler/compile_metadata.dart";
-import "package:angular/src/core/change_detection.dart"
-    show ChangeDetectionStrategy;
-import "package:angular/src/core/metadata/lifecycle_hooks.dart"
-    show LifecycleHooks;
-import "package:angular/src/core/metadata/view.dart" show ViewEncapsulation;
+import 'package:angular/src/compiler/compile_metadata.dart';
+import 'package:angular/src/core/metadata/view.dart' show ViewEncapsulation;
 
 void main() {
   group("CompileMetadata", () {
-    CompileTypeMetadata fullTypeMeta;
-    CompileTemplateMetadata fullTemplateMeta;
-    CompileDirectiveMetadata fullDirectiveMeta;
-    setUp(() {
-      var diDep = new CompileDiDependencyMetadata(
-          isAttribute: true,
-          isSelf: true,
-          isHost: true,
-          isSkipSelf: true,
-          isOptional: true,
-          token: new CompileTokenMetadata(value: "someToken"));
-      fullTypeMeta = new CompileTypeMetadata(
-          name: "SomeType",
-          moduleUrl: "someUrl",
-          isHost: true,
-          diDeps: [diDep]);
-      fullTemplateMeta = new CompileTemplateMetadata(
-          encapsulation: ViewEncapsulation.Emulated,
-          template: "<a></a>",
-          templateUrl: "someTemplateUrl",
-          styles: ["someStyle"],
-          styleUrls: ["someStyleUrl"],
-          ngContentSelectors: ["*"]);
-      fullDirectiveMeta = CompileDirectiveMetadata.create(
-          selector: "someSelector",
-          isComponent: true,
-          type: fullTypeMeta,
-          template: fullTemplateMeta,
-          changeDetection: ChangeDetectionStrategy.Default,
-          inputs: [
-            "someProp"
-          ],
-          outputs: [
-            "someEvent"
-          ],
-          host: {
-            "(event1)": "handler1",
-            "[prop1]": "expr1",
-            "attr1": "attrValue2"
-          },
-          lifecycleHooks: [
-            LifecycleHooks.OnChanges
-          ],
-          providers: [
-            new CompileProviderMetadata(
-                token: new CompileTokenMetadata(value: "token"),
-                multi: true,
-                useClass: fullTypeMeta,
-                useExisting: new CompileTokenMetadata(
-                    identifier: new CompileIdentifierMetadata(name: "someName"),
-                    identifierIsInstance: true),
-                useFactory: new CompileFactoryMetadata(
-                    name: "someName", diDeps: [diDep]),
-                useValue: "someValue")
-          ],
-          viewProviders: [
-            new CompileProviderMetadata(
-                token: new CompileTokenMetadata(value: "token"),
-                useClass: fullTypeMeta,
-                useExisting: new CompileTokenMetadata(
-                    identifier:
-                        new CompileIdentifierMetadata(name: "someName")),
-                useFactory: new CompileFactoryMetadata(
-                    name: "someName", diDeps: [diDep]),
-                useValue: "someValue")
-          ],
-          queries: [
-            new CompileQueryMetadata(
-                selectors: [new CompileTokenMetadata(value: "selector")],
-                descendants: true,
-                first: false,
-                propertyName: "prop",
-                read: new CompileTokenMetadata(value: "readToken"))
-          ],
-          viewQueries: [
-            new CompileQueryMetadata(
-                selectors: [new CompileTokenMetadata(value: "selector")],
-                descendants: true,
-                first: false,
-                propertyName: "prop",
-                read: new CompileTokenMetadata(value: "readToken"))
-          ]);
-    });
-    group("CompileIdentifierMetadata", () {
-      test("should serialize with full data", () {
-        var full = new CompileIdentifierMetadata(
-            name: "name",
-            moduleUrl: "module",
-            value: [
-              "one",
-              ["two"]
-            ]);
-        expect(CompileIdentifierMetadata.fromJson(full.toJson()).toJson(),
-            full.toJson());
-      });
-      test("should serialize with no data", () {
-        var empty = new CompileIdentifierMetadata();
-        expect(CompileIdentifierMetadata.fromJson(empty.toJson()).toJson(),
-            empty.toJson());
-      });
-    });
-    group("Directive", () {
-      test("should serialize with full data", () {
-        expect(
-            CompileDirectiveMetadata
-                .fromJson(fullDirectiveMeta.toJson())
-                .toJson(),
-            fullDirectiveMeta.toJson());
-      });
-      test("should serialize with no data", () {
-        var empty = CompileDirectiveMetadata.create();
-        expect(CompileDirectiveMetadata.fromJson(empty.toJson()).toJson(),
-            empty.toJson());
-      });
-    });
-    group("TypeMetadata", () {
-      test("should serialize with full data", () {
-        expect(CompileTypeMetadata.fromJson(fullTypeMeta.toJson()).toJson(),
-            fullTypeMeta.toJson());
-      });
-      test("should serialize with no data", () {
-        var empty = new CompileTypeMetadata();
-        expect(CompileTypeMetadata.fromJson(empty.toJson()).toJson(),
-            empty.toJson());
-      });
-    });
     group("TemplateMetadata", () {
       test("should use ViewEncapsulation.Emulated by default", () {
         expect(new CompileTemplateMetadata(encapsulation: null).encapsulation,
             ViewEncapsulation.Emulated);
-      });
-      test("should serialize with full data", () {
-        expect(
-            CompileTemplateMetadata
-                .fromJson(fullTemplateMeta.toJson())
-                .toJson(),
-            fullTemplateMeta.toJson());
-      });
-      test("should serialize with no data", () {
-        var empty = new CompileTemplateMetadata();
-        expect(CompileTemplateMetadata.fromJson(empty.toJson()).toJson(),
-            empty.toJson());
       });
     });
     group("Pipe", () {

--- a/angular/lib/src/compiler/output/dart_emitter.dart
+++ b/angular/lib/src/compiler/output/dart_emitter.dart
@@ -522,7 +522,7 @@ class _DartEmitterVisitor extends AbstractEmitterVisitor
         }
         importsWithPrefixes[value.moduleUrl] = prefix;
       }
-    } else if (value.emitPrefix) {
+    } else {
       prefix = value.prefix ?? '';
     }
     if (isDeferred) {
@@ -533,7 +533,7 @@ class _DartEmitterVisitor extends AbstractEmitterVisitor
       if (value.moduleUrl != null && value.moduleUrl != _moduleUrl) {
         ctx.print(prefix.isEmpty ? '' : '$prefix.');
       }
-      if (value.emitPrefix && value.prefix != null && value.prefix.isNotEmpty) {
+      if (value.prefix != null && value.prefix.isNotEmpty) {
         ctx.print('${value.prefix}.');
       }
     }

--- a/angular/lib/src/compiler/view_compiler/compile_element.dart
+++ b/angular/lib/src/compiler/view_compiler/compile_element.dart
@@ -388,18 +388,17 @@ class CompileElement extends CompileNode {
     }
 
     CompileIdentifierMetadata prefixedId = new CompileIdentifierMetadata(
-        name: 'loadLibrary', prefix: prefix, emitPrefix: true);
+        name: 'loadLibrary', prefix: prefix);
     CompileIdentifierMetadata nestedComponentId = new CompileIdentifierMetadata(
         name: getViewFactoryName(deferredElement.component, 0));
     CompileIdentifierMetadata templatePrefixId = new CompileIdentifierMetadata(
-        name: 'loadLibrary', prefix: templatePrefix, emitPrefix: true);
+        name: 'loadLibrary', prefix: templatePrefix);
 
     CompileIdentifierMetadata templateInitializer =
         new CompileIdentifierMetadata(
             name: 'initReflector',
             moduleUrl: nestedComponentId.moduleUrl,
             prefix: templatePrefix,
-            emitPrefix: true,
             value: nestedComponentId.value);
 
     var templateRefExpr =

--- a/angular/lib/src/source_gen/template_compiler/compile_metadata.dart
+++ b/angular/lib/src/source_gen/template_compiler/compile_metadata.dart
@@ -382,8 +382,7 @@ class CompileTypeMetadataVisitor
     return new CompileIdentifierMetadata(
         name: function.name,
         moduleUrl: moduleUrl(function),
-        prefix: prefix,
-        emitPrefix: true);
+        prefix: prefix);
   }
 
   CompileFactoryMetadata _factoryForFunction(
@@ -398,7 +397,6 @@ class CompileTypeMetadataVisitor
       name: function.name,
       moduleUrl: moduleUrl(function),
       prefix: prefix,
-      emitPrefix: true,
       diDeps: typesOrTokens != null
           ? typesOrTokens.map(_factoryDiDep).toList()
           : _getCompileDiDependencyMetadata(function.parameters, function),


### PR DESCRIPTION
1) Remove toJson/fromJson. This was only used in the old transformers.
2) Remove emitPrefix, which is always true now.