### PR TITLE
Use @MirrorsUsed(..) annotiation

### DIFF
--- a/angular/lib/src/core/reflection/reflection_capabilities.dart
+++ b/angular/lib/src/core/reflection/reflection_capabilities.dart
@@ -1,3 +1,4 @@
+@MirrorsUsed(symbols: 'classMirror')
 import 'dart:mirrors';
 
 import 'package:angular/src/core/metadata/lifecycle_hooks.dart';


### PR DESCRIPTION
This commit introduces the @MirrorsUsed(..) annotation as described here: https://api.dartlang.org/stable/1.24.2/dart-mirrors/MirrorsUsed-class.html
This leads to less generated code:
Before: `Compiled 6,085,576 characters Dart to 9,543,914 characters JavaScript in 19.4 seconds`
After: `Compiled 6,085,628 characters Dart to 787,162 characters JavaScript in 4.60 seconds`