### PR TITLE
fix(Travis): Ignore "uri_has_not_been_generated".

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,10 @@ analyzer:
    unused_import: error
    unused_local_variable: error
    dead_code: error
+
+   # Allow importing .template.dart files without an analyzer error.
+   uri_has_not_been_generated: ignore
+
    ### Useful to uncomment during development to remove the noise of the many
    ### deprecated APIs.
    # deprecated_member_use: ignore


### PR DESCRIPTION
We are going to start telling users to import ".template.dart" files, so we need this in order to avoid the analyzer exception. We might want to document this as a recommendation for all users in the future/as part of 4.0.

PiperOrigin-RevId: 162527911