### PR TITLE
WIP: Use 1.24 Function syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 
 dart:
   # Temporarily disabled. We only have the stable release of Dartium installed.
-  # - dev
+  - dev
   - stable
 
 env:

--- a/_tests/pubspec.yaml
+++ b/_tests/pubspec.yaml
@@ -14,6 +14,7 @@ dev_dependencies:
 
 # DO NOT REMOVE. We don't publish this package, it is just for testing.
 dependency_overrides:
+  analyzer: 0.31.0-alpha.0
   angular:
     path: ../angular
   angular_compiler:

--- a/angular/lib/src/common/forms/directives/default_value_accessor.dart
+++ b/angular/lib/src/common/forms/directives/default_value_accessor.dart
@@ -1,6 +1,5 @@
 import 'dart:js_util' as js_util;
 
-import 'package:func/func.dart' show VoidFunc0, VoidFunc1;
 import 'package:angular/core.dart' show Directive, ElementRef, Provider;
 
 import 'control_value_accessor.dart';
@@ -29,12 +28,12 @@ const DEFAULT_VALUE_ACCESSOR = const Provider(NG_VALUE_ACCESSOR,
     ])
 class DefaultValueAccessor implements ControlValueAccessor {
   ElementRef _elementRef;
-  VoidFunc1 onChange = (dynamic _) {};
+  void Function(dynamic) onChange = (dynamic _) {};
   void touchHandler() {
     onTouched();
   }
 
-  VoidFunc0 onTouched = () {};
+  void Function() onTouched = () {};
   DefaultValueAccessor(this._elementRef);
   @override
   void writeValue(dynamic value) {

--- a/angular/lib/src/common/forms/directives/number_value_accessor.dart
+++ b/angular/lib/src/common/forms/directives/number_value_accessor.dart
@@ -8,8 +8,6 @@ import 'control_value_accessor.dart'
 const NUMBER_VALUE_ACCESSOR = const Provider(NG_VALUE_ACCESSOR,
     useExisting: NumberValueAccessor, multi: true);
 
-typedef dynamic _SimpleChangeFn(value);
-
 /// The accessor for writing a number value and listening to changes that is used by the
 /// [NgModel], [NgFormControl], and [NgControlName] directives.
 ///
@@ -30,7 +28,7 @@ typedef dynamic _SimpleChangeFn(value);
     ])
 class NumberValueAccessor implements ControlValueAccessor {
   final ElementRef _elementRef;
-  _SimpleChangeFn onChange = (_) {};
+  dynamic Function(dynamic) onChange = (_) {};
   void touchHandler() {
     onTouched();
   }

--- a/angular/lib/src/common/forms/directives/radio_control_value_accessor.dart
+++ b/angular/lib/src/common/forms/directives/radio_control_value_accessor.dart
@@ -1,6 +1,5 @@
 import 'dart:js_util' as js_util;
 
-import 'package:func/func.dart' show Func0, VoidFunc0;
 import 'package:angular/core.dart'
     show Directive, ElementRef, Provider, Input, OnInit, OnDestroy, Injector;
 import 'package:angular/di.dart' show Injectable;
@@ -89,8 +88,8 @@ class RadioControlValueAccessor
     onTouched();
   }
 
-  VoidFunc0 onChange = () {};
-  Func0 onTouched = () {};
+  void Function() onChange = () {};
+  Function() onTouched = () {};
   RadioControlValueAccessor(this._elementRef, this._registry, this._injector);
 
   @override

--- a/angular/lib/src/common/forms/directives/select_control_value_accessor.dart
+++ b/angular/lib/src/common/forms/directives/select_control_value_accessor.dart
@@ -1,6 +1,5 @@
 import 'dart:html';
 
-import 'package:func/func.dart' show Func0, VoidFunc1;
 import 'package:angular/core.dart'
     show Directive, Provider, ElementRef, Input, OnDestroy;
 import 'package:angular/di.dart' show Host, Optional;
@@ -45,13 +44,13 @@ class SelectControlValueAccessor implements ControlValueAccessor {
   dynamic value;
   final Map<String, dynamic> _optionMap = new Map<String, dynamic>();
   num _idCounter = 0;
-  VoidFunc1 onChange = (dynamic _) {};
+  void Function(dynamic) onChange = (dynamic _) {};
 
   void touchHandler() {
     onTouched();
   }
 
-  Func0 onTouched = () {};
+  Function() onTouched = () {};
   SelectControlValueAccessor(this._elementRef);
 
   @override

--- a/angular/lib/src/common/pipes/replace_pipe.dart
+++ b/angular/lib/src/common/pipes/replace_pipe.dart
@@ -46,7 +46,7 @@ class ReplacePipe implements PipeTransform {
       throw new InvalidPipeArgumentException(ReplacePipe, replacement);
     }
     // template fails with literal RegExp e.g /pattern/igm
-    if (replacement is _Matcher) {
+    if (replacement is String Function(Match)) {
       var rgxPattern =
           pattern is String ? new RegExp(pattern) : (pattern as RegExp);
       return input.replaceAllMapped(rgxPattern, replacement);
@@ -68,5 +68,3 @@ class ReplacePipe implements PipeTransform {
     return replacement is String || replacement is Function;
   }
 }
-
-typedef String _Matcher(Match _);

--- a/angular/lib/src/common/pipes/uppercase_pipe.dart
+++ b/angular/lib/src/common/pipes/uppercase_pipe.dart
@@ -1,4 +1,4 @@
-import 'package:angular/di.dart' show PipeTransform, Injectable, Pipe;
+import 'package:angular/di.dart' show PipeTransform, Pipe;
 
 import 'invalid_pipe_argument_exception.dart' show InvalidPipeArgumentException;
 

--- a/angular/lib/src/compiler/selector.dart
+++ b/angular/lib/src/compiler/selector.dart
@@ -340,8 +340,6 @@ class SelectorMatcher {
   }
 }
 
-typedef void MatchCallbackHandler(CssSelector, dynamic);
-
 class SelectorListContext {
   List<CssSelector> selectors;
   bool alreadyMatched = false;

--- a/angular/lib/src/compiler/view_compiler/view_binder.dart
+++ b/angular/lib/src/compiler/view_compiler/view_binder.dart
@@ -1,8 +1,8 @@
 import 'package:source_span/source_span.dart';
 import '../../core/linker/view_type.dart';
+import '../expression_parser/parser.dart';
 import '../output/output_ast.dart' as o;
 import '../schema/element_schema_registry.dart';
-import '../expression_parser/parser.dart';
 import "../template_ast.dart"
     show
         TemplateAst,

--- a/angular/lib/src/core/linker/app_view.dart
+++ b/angular/lib/src/core/linker/app_view.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:js_util' as js_util;
 
-import 'package:func/func.dart';
 import 'package:meta/meta.dart';
 import 'package:angular/src/core/change_detection/change_detection.dart'
     show ChangeDetectorRef, ChangeDetectionStrategy, ChangeDetectorState;
@@ -557,7 +556,7 @@ abstract class AppView<T> {
     domRootRendererIsDirty = true;
   }
 
-  VoidFunc1<E> eventHandler0<E>(VoidFunc0 handler) {
+  void Function(E) eventHandler0<E>(void Function() handler) {
     return (E event) {
       markPathToRootAsCheckOnce();
       if (NgZone.isInAngularZone()) {
@@ -576,7 +575,7 @@ abstract class AppView<T> {
   // parameter of the event listener is a subclass of Event. The Event passed in
   // from EventTarget.addEventListener() can then be safely coerced back to its
   // known type.
-  VoidFunc1<E> eventHandler1<E, F extends E>(VoidFunc1<F> handler) {
+  void Function(E) eventHandler1<E, F extends E>(void Function(F) handler) {
     return (E event) {
       markPathToRootAsCheckOnce();
       if (NgZone.isInAngularZone()) {

--- a/angular/lib/src/core/zone/ng_zone.dart
+++ b/angular/lib/src/core/zone/ng_zone.dart
@@ -370,20 +370,17 @@ class NgZone {
   Stream get onUnstable => _onUnstableController.stream;
 }
 
-typedef void ZeroArgFunction();
-typedef void ErrorHandlingFn(error, stackTrace);
-
 /// A `Timer` wrapper that lets you specify additional functions to call when it
 /// is cancelled.
 class WrappedTimer implements Timer {
   Timer _timer;
-  ZeroArgFunction _onCancelCb;
+  void Function() _onCancelCb;
 
   WrappedTimer(Timer timer) {
     _timer = timer;
   }
 
-  void addOnCancelCb(ZeroArgFunction onCancelCb) {
+  void addOnCancelCb(void Function() onCancelCb) {
     if (this._onCancelCb != null) {
       throw "On cancel cb already registered";
     }

--- a/angular/lib/src/debug/debug_app_view.dart
+++ b/angular/lib/src/debug/debug_app_view.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 import 'dart:html';
 import 'dart:js_util' as js_util;
 
-import 'package:func/func.dart';
 import 'package:js/js.dart' as js;
 import 'package:meta/meta.dart';
 import 'package:angular/src/core/change_detection/change_detection.dart'
@@ -144,7 +143,7 @@ class DebugAppView<T> extends AppView<T> {
   }
 
   @override
-  VoidFunc1<E> eventHandler0<E>(VoidFunc0 handler) {
+  void Function(E) eventHandler0<E>(void Function() handler) {
     return (E event) {
       _resetDebug();
       try {
@@ -157,7 +156,7 @@ class DebugAppView<T> extends AppView<T> {
   }
 
   @override
-  VoidFunc1<E> eventHandler1<E, F extends E>(VoidFunc1<F> handler) {
+  void Function(E) eventHandler1<E, F extends E>(void Function(F) handler) {
     return (E event) {
       _resetDebug();
       try {

--- a/angular/lib/src/platform/browser/location/platform_location.dart
+++ b/angular/lib/src/platform/browser/location/platform_location.dart
@@ -35,7 +35,5 @@ abstract class PlatformLocation {
   void back();
 }
 
-typedef String BaseHRefFromDOMProvider();
-
 /// Returns base href from browser location.
-BaseHRefFromDOMProvider baseHRefFromDOM;
+String Function() baseHRefFromDOM;

--- a/angular/lib/src/source_gen/template_compiler/dart_object_utils.dart
+++ b/angular/lib/src/source_gen/template_compiler/dart_object_utils.dart
@@ -141,13 +141,12 @@ DartObject getField(DartObject object, String field) {
   return getField(object.getField('(super)'), field);
 }
 
-typedef T RecurseFn<T>(DartObject obj);
-
 /// Visits all of the [DartObject]s, accumulating the results of [RecurseFn].
 ///
 /// If the DartObject is a list, then it will recursively visitAll
-/// on that list. Otherwise, then it will call [RecurseFn] on the object.
-List<T> visitAll<T>(Iterable<DartObject> objs, RecurseFn<T> recurseFn) {
+/// on that list. Otherwise, then it will call [recurseFn] on the object.
+List<T> visitAll<T>(
+    Iterable<DartObject> objs, T Function(DartObject) recurseFn) {
   var metadata = <T>[];
   for (DartObject obj in objs) {
     var maybeList = obj.toListValue();

--- a/angular/lib/src/transform/common/zone.dart
+++ b/angular/lib/src/transform/common/zone.dart
@@ -8,14 +8,12 @@ import 'package:angular/src/compiler/offline_compiler.dart';
 
 import 'logging.dart' show forwardLogRecord;
 
-typedef Future _SimpleCallback();
-
 // Keys used to store zone local values on the current zone.
 final _loggerKey = #loggingZonedLoggerKey;
 final _templateCompilerKey = #templateCompilerKey;
 
 /// Executes `fn` inside a new `Zone` with the provided zone-local values.
-Future<dynamic> exec(_SimpleCallback fn,
+Future<dynamic> exec(Future Function() fn,
     {TransformLogger log, OfflineCompiler templateCompiler}) async {
   return runZoned(() async {
     var loggerSubscription = Logger.root.onRecord.listen(forwardLogRecord);

--- a/angular/pubspec.yaml
+++ b/angular/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
 
 # === vvv REMOVE WHEN PUBLISHING vvv ===
 dependency_overrides:
+  analyzer: 0.31.0-alpha.0
   angular_compiler:
       path: ../angular_compiler
 # === ^^^ REMOVE WHEN PUBLISHING ^^^ ===

--- a/angular/pubspec.yaml
+++ b/angular/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   collection: '^1.12.0'
   csslib: ^0.14.0
   dart_style: '>=0.1.8 <2.0.0'
-  func: '>=0.1.0 <2.0.0'
   glob: ^1.0.0
   html: '>=0.12.0 <0.14.0'
   intl: '>=0.13.0 <0.16.0'

--- a/angular_test/pubspec.yaml
+++ b/angular_test/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
 
 # === vvv REMOVE WHEN PUBLISHING vvv ===
 dependency_overrides:
+  analyzer: 0.31.0-alpha.0
   angular:
     path: ../angular
   angular_compiler:


### PR DESCRIPTION
Blocked on a new analyzer release - https://github.com/dart-lang/sdk/issues/30239

Using alpha pkg/analyzer to see if travis gets happy
Looks like we need to update to use the 1.25.0-dev SDK, too!