### PR TITLE
Ensure angular_foo pkg has a named angular_foo library for forms and test

### DIFF
--- a/angular_forms/lib/angular_forms.dart
+++ b/angular_forms/lib/angular_forms.dart
@@ -5,7 +5,7 @@
 ///
 /// This module is not included in the `angular` module; you must import the
 /// forms module explicitly.
-library angular_forms;
+library angular_forms; // name the library so we can run dartdoc on it by name.
 
 import 'src/directives/radio_control_value_accessor.dart'
     show RadioControlRegistry;

--- a/angular_forms/lib/angular_forms.dart
+++ b/angular_forms/lib/angular_forms.dart
@@ -1,10 +1,11 @@
-// This module is used for handling user input, by defining and building a
-// [ControlGroup] that consists of [Control] objects, and mapping them onto
-// the DOM. [Control] objects can then be used to read information from the
-// form DOM elements.
-//
-// This module is not included in the `angular2` module; you must import the
-// forms module explicitly.
+/// This module is used for handling user input, by defining and building a
+/// [ControlGroup] that consists of [Control] objects, and mapping them onto
+/// the DOM. [Control] objects can then be used to read information from the
+/// form DOM elements.
+///
+/// This module is not included in the `angular` module; you must import the
+/// forms module explicitly.
+library angular_forms;
 
 import 'src/directives/radio_control_value_accessor.dart'
     show RadioControlRegistry;

--- a/angular_test/lib/angular_test.dart
+++ b/angular_test/lib/angular_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library angular_test;
+library angular_test; // name the library so we can run dartdoc on it by name.
 
 export 'src/frontend.dart'
     show

--- a/angular_test/lib/angular_test.dart
+++ b/angular_test/lib/angular_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+library angular_test;
+
 export 'src/frontend.dart'
     show
         disposeAnyRunningTest,


### PR DESCRIPTION
Currently both `angular_forms` and `angular_test` have most of their features exported via the unnamed library. I'm not sure this has much of an impact other than possible surprising messages from dartdoc when trying to build the docs by naming the library; this currently fails -- e.g.:

```nocode
> pub global run dartdoc --output doc/api --include=angular_test

Generating documentation for 'angular_test' into /Users/chalin/git/dart/angular/angular_test/doc/api/

parsing lib/angular_test.dart...
parsing lib/compatibility.dart...
parsed 2 files in 6.8 seconds

Generation failed: Did not find: [angular_test] in known libraries: [, angular_test.compatibility]
package:dartdoc/dartdoc.dart 143                                                        DartDoc.generateDocs
...
```

Regardless, having a library named angular_foo in the angular_foo package seems like a good idea.

I could have opened an issue, but it seemed almost just as easy to submit a fix.

p.s. Maybe the same thing needs to be done to `angular_compiler`?

cc @kwalrath @matanlurey