### PR TITLE
router: tweak readme

### DIFF
--- a/angular_router/README.md
+++ b/angular_router/README.md
@@ -1,4 +1,3 @@
-# angular_router
 <!-- Badges -->
 
 [![Pub package](https://img.shields.io/pub/v/angular_router.svg)][pub_angular_router]
@@ -6,12 +5,12 @@
 The [AngularDart][webdev_angular] router enables navigation from one view to
 the next as users perform application tasks.
 
-The 1.0 version of `angular_router` is just a port of the router that was in
+The 1.0 version of `angular_router` is a port of the router that was in
 the core `angular` package. Only critical bug fixes are planned for the 1.0
 router. A significant refactoring is in progress, which is expected to result
 in a 2.0 version of `angular_router`.
 
-Resources:
+### Resources:
 
 * Documentation:
   [routing guide][webdev_router],


### PR DESCRIPTION
All places where the README is displayed, the title header is redundant – removing