### PR TITLE
Optimization for Barback: Don't wait for outputs.

### DIFF
--- a/_tests/test/common/forms/integration_test.dart
+++ b/_tests/test/common/forms/integration_test.dart
@@ -872,7 +872,9 @@ class InputWithoutTypeTest {
 }
 
 @Component(
-    selector: 'textarea-test', directives: const [formDirectives], template: '''
+    selector: 'textarea-test',
+    directives: const [formDirectives],
+    template: '''
 <div [ngFormModel]="form">
   <textarea ngControl="text"></textarea>
 </div>''')
@@ -881,7 +883,9 @@ class TextAreaTest {
 }
 
 @Component(
-    selector: 'checkbox-test', directives: const [formDirectives], template: '''
+    selector: 'checkbox-test',
+    directives: const [formDirectives],
+    template: '''
 <div [ngFormModel]="form">
   <input type="checkbox" ngControl="checkbox">
 </div>''')
@@ -890,7 +894,9 @@ class CheckboxTest {
 }
 
 @Component(
-    selector: 'number-test', directives: const [formDirectives], template: '''
+    selector: 'number-test',
+    directives: const [formDirectives],
+    template: '''
 <div [ngFormModel]="form">
   <input type="number" ngControl="num">
 </div>''')

--- a/_tests/test/compiler/expression_parser/parser_test.dart
+++ b/_tests/test/compiler/expression_parser/parser_test.dart
@@ -453,9 +453,11 @@ void main() {
         checkInterpolation("{{ a < b ? a : b }}");
       });
       test("should parse expression with newline characters", () {
-        checkInterpolation('''{{ \'foo\' +
+        checkInterpolation(
+            '''{{ \'foo\' +
  \'bar\' +
- \'baz\' }}''', '''{{ "foo" + "bar" + "baz" }}''');
+ \'baz\' }}''',
+            '''{{ "foo" + "bar" + "baz" }}''');
       });
       group("comments", () {
         test("should ignore comments in interpolation expressions", () {

--- a/_tests/test/core/debug/debug_node_test.dart
+++ b/_tests/test/core/debug/debug_node_test.dart
@@ -239,20 +239,27 @@ class ConditionalContentComp {
   bool myBool = false;
 }
 
-@Component(selector: "conditional-parent-comp", template: '''
+@Component(
+    selector: "conditional-parent-comp",
+    template: '''
         <span class="parent" [innerHtml]="parentBinding"></span>
         <cond-content-comp class="cond-content-comp-class">
           <span class="from-parent"></span>
-        </cond-content-comp>''', directives: const [ConditionalContentComp])
+        </cond-content-comp>''',
+    directives: const [ConditionalContentComp])
 class ConditionalParentComp {
   String parentBinding = "OriginalParent";
 }
 
-@Component(selector: "using-for", viewProviders: const [], template: '''
+@Component(
+    selector: "using-for",
+    viewProviders: const [],
+    template: '''
         <span *ngFor="let thing of stuff" [innerHtml]="thing"></span>
         <ul message="list">
            <li *ngFor="let item of stuff" [innerHtml]="item"></li>
-        </ul>''', directives: const [NgFor, MessageDir])
+        </ul>''',
+    directives: const [NgFor, MessageDir])
 class UsingFor {
   List<String> stuff;
   UsingFor() {
@@ -260,7 +267,9 @@ class UsingFor {
   }
 }
 
-@Component(selector: "bank-account", template: '''
+@Component(
+    selector: "bank-account",
+    template: '''
    Bank Name: {{bank}}
    Account Id: {{id}}
  ''')
@@ -297,7 +306,9 @@ class CustomEmitter {
   Stream<dynamic> get myevent => _myEvent.stream;
 }
 
-@Component(selector: "events-comp", template: '''
+@Component(
+    selector: "events-comp",
+    template: '''
         <button (click)="handleClick()"></button>''')
 class EventsComp {
   bool clicked;

--- a/_tests/test/core/linker/query_integration_test.dart
+++ b/_tests/test/core/linker/query_integration_test.dart
@@ -544,15 +544,18 @@ class TestsTranscludedContentChildrenComponent {}
 @Directive(selector: '[inert]')
 class InertDirective {}
 
-@Component(selector: 'unrelated-changes', template: '''
+@Component(
+    selector: 'unrelated-changes',
+    template: '''
 <div text="1"></div>
 <div *ngIf="showInertDirective" inert></div>
 <div>{{text}}</div>
-  ''', directives: const [
-  InertDirective,
-  NgIf,
-  TextDirective,
-])
+  ''',
+    directives: const [
+      InertDirective,
+      NgIf,
+      TextDirective,
+    ])
 class UnrelatedChangesComponent extends TextDirectivesRenderer {
   bool showInertDirective = true;
 

--- a/_tests/test/source_gen/template_compiler/find_components_test.dart
+++ b/_tests/test/source_gen/template_compiler/find_components_test.dart
@@ -54,10 +54,13 @@ Future<NormalizedComponentWithViewDirectives> resolveAndFindComponent(
   String source,
 ) async {
   final testAssetId = new AssetId('find_components_test', 'lib/test.dart');
-  final library = await resolveSource('''
+  final library = await resolveSource(
+      '''
     import 'package:angular/angular.dart';
     $source
-  ''', (r) => r.libraryFor(testAssetId), inputId: testAssetId);
+  ''',
+      (r) => r.libraryFor(testAssetId),
+      inputId: testAssetId);
   final artifacts = findComponentsAndDirectives(library);
   return artifacts.components.first;
 }

--- a/_tests/test/source_gen/template_compiler/test_files/core_directives.dart
+++ b/_tests/test/source_gen/template_compiler/test_files/core_directives.dart
@@ -1,11 +1,14 @@
 import 'package:angular/angular.dart';
 
-@Component(selector: 'test-foo', template: '''
+@Component(
+    selector: 'test-foo',
+    template: '''
     <div *ngIf="foo">Foo</div>
     <div *ngFor="let bar of bars">
       <span>{{bar}}</span>
     </div>
-    ''', directives: const [NgIf, NgFor])
+    ''',
+    directives: const [NgIf, NgFor])
 class TestFooComponent {
   final bool foo = true;
   final List<String> bars = ['bar'];

--- a/angular_compiler/test/src/resolve.dart
+++ b/angular_compiler/test/src/resolve.dart
@@ -12,7 +12,8 @@ const angular = 'package:angular/angular.dart';
 /// Resolves [source] code as-if it is implemented with an AngularDart import.
 ///
 /// Returns the resolved library as `package:test_lib/test_lib.dart`.
-Future<LibraryElement> resolveLibrary(String source) => resolveSource('''
+Future<LibraryElement> resolveLibrary(String source) => resolveSource(
+    '''
       library _test;
       import '$angular';\n\n$source''',
     (resolver) => resolver.findLibraryByName('_test'),


### PR DESCRIPTION
/cc @chalin if you want to see if this improves build-times for the examples.

This is based on a non-exhaustive theory that waiting for outputs in Barback is the source of significant (blocking) time, and can be optimized away in most cases where `$exclude` and `$include` are not used.

In the cases they are, a new optional flag, `generator_inputs`, is available. We could optionally flip this as well and support something like a `not_generator_inputs`, if that is more useful. 

**FOR FEEDBACK ONLY: DO NOT MERGE**