### PR TITLE
Stop passing functions to assert – only bool expressions

### DIFF
--- a/angular/lib/src/core/application_ref.dart
+++ b/angular/lib/src/core/application_ref.dart
@@ -27,7 +27,7 @@ bool _inPlatformCreate = false;
 /// Creates a platform.
 /// Platforms have to be eagerly created via this function.
 PlatformRefImpl createPlatform(Injector injector) {
-  assert(() {
+  assert((() {
     if (_inPlatformCreate) {
       throw new BaseException('Already creating a platform...');
     }
@@ -36,7 +36,7 @@ PlatformRefImpl createPlatform(Injector injector) {
           'previous one to create a new one.');
     }
     return true;
-  });
+  })());
   if (isDartVM && !assertionsEnabled()) {
     window.console.warn(''
         'When using Dartium, CHECKED mode is recommended to catch type and '
@@ -126,13 +126,13 @@ class PlatformRefImpl extends PlatformRef {
 
   /// Given an injector, gets platform initializers to initialize at bootstrap.
   void init(Injector injector) {
-    assert(() {
+    assert((() {
       if (!_inPlatformCreate) {
         throw new BaseException(
             'Platforms have to be initialized via `createPlatform`!');
       }
       return true;
-    });
+    })());
     _injector = injector;
 
     List initializers = injector.get(PLATFORM_INITIALIZER, null);
@@ -338,14 +338,14 @@ class ApplicationRefImpl extends ApplicationRef {
   }
 
   ComponentRef<T> bootstrap<T>(ComponentFactory<T> componentFactory) {
-    assert(() {
+    assert((() {
       if (!_asyncInitDone) {
         throw new BaseException(
             'Cannot bootstrap as there are still asynchronous initializers '
             'running. Wait for them using waitForAsyncInitializers().');
       }
       return true;
-    });
+    })());
 
     return run(() {
       _rootComponentFactories.add(componentFactory);
@@ -413,12 +413,12 @@ class ApplicationRefImpl extends ApplicationRef {
     // Protect against tick being called recursively in development mode.
     //
     // This is mostly to assert valid changes to the framework, not user code.
-    assert(() {
+    assert((() {
       if (_runningTick) {
         throw new BaseException('ApplicationRef.tick is called recursively');
       }
       return true;
-    });
+    })());
 
     // Run the top-level 'tick' (i.e. detectChanges on root components).
     try {

--- a/angular/lib/src/core/linker/app_view.dart
+++ b/angular/lib/src/core/linker/app_view.dart
@@ -369,12 +369,12 @@ abstract class AppView<T> {
     }
 
     // Sanity check in dev-mode that a destroyed view is not checked again.
-    assert(() {
+    assert((() {
       if (viewData.destroyed) {
         throw new ViewDestroyedException('detectChanges');
       }
       return true;
-    });
+    })());
 
     if (lastGuardedView != null) {
       // Run change detection in "slow-mode" to catch thrown exceptions.

--- a/angular/lib/src/di/reflector.dart
+++ b/angular/lib/src/di/reflector.dart
@@ -30,12 +30,12 @@ void registerComponent(Type type, dynamic /*ComponentFactory*/ component) {
 /// Returns the static factory for [type].
 /*ComponentFactory*/ dynamic getComponent(Type type) {
   final component = _components[type];
-  assert(() {
+  assert((() {
     if (component == null) {
       throw new StateError('Could not find a component factory for $type.');
     }
     return true;
-  });
+  })());
   return component;
 }
 
@@ -52,12 +52,12 @@ void registerFactory(Object typeOrFunc, Function factory) {
 /// Returns a factory function for creating [type].
 Function getFactory(Type type) {
   final factory = _factories[type];
-  assert(() {
+  assert((() {
     if (factory == null) {
       throw new StateError('Could not find a factory for $type.');
     }
     return true;
-  });
+  })());
   return factory;
 }
 

--- a/angular/lib/src/security/style_sanitizer.dart
+++ b/angular/lib/src/security/style_sanitizer.dart
@@ -104,10 +104,10 @@ String internalSanitizeStyle(String value) {
     }
     if (!failed) return value;
   }
-  assert(() {
+  assert((() {
     _logger.warning('Sanitizing unsafe style value $value '
         '(see http://g.co/ng/security#xss).');
     return true;
-  });
+  })());
   return 'unsafe';
 }


### PR DESCRIPTION
DDC in Dart SDK 2.0.0-dev.0.0 removed this feature

More to come: https://github.com/dart-lang/sdk/issues/30326