### PR TITLE
angular_router 2: fix to JsObject has no getter 'queryParameters' issue

### DIFF
--- a/angular_router/lib/src/router/router_coordinator.dart
+++ b/angular_router/lib/src/router/router_coordinator.dart
@@ -83,9 +83,9 @@ class _RouterJs {
               navigationParams == null
                   ? null
                   : new NavigationParams(
-                      queryParameters: navigationParams.queryParameters,
-                      fragment: navigationParams.fragment,
-                      updateUrl: navigationParams.updateUrl))
+                      queryParameters: _objToMap(navigationParams['queryParameters']) ?? const {},
+                      fragment: navigationParams['fragment'] ?? '',
+                      updateUrl: navigationParams['updateUrl'] ?? true))
           .then((result) => callBack.callMethod('onCompletion', [result]));
     };
   }
@@ -125,3 +125,11 @@ class _NavigationParamsJs {
   external String get fragment;
   external bool get updateUrl;
 }
+
+Map _objToMap(o) => o == null ? o : new Map.fromIterable(_jsKeys(o), value: (key) => _jsGetProp(o, key));
+
+@JS('Object.getProperty')
+external List<String> _jsGetProp(jsObject, key);
+
+@JS('Object.keys')
+external List<String> _jsKeys(jsObject);

--- a/angular_router/lib/src/router/router_coordinator.dart
+++ b/angular_router/lib/src/router/router_coordinator.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:js';
 
 import 'package:js/js.dart';
+import 'package:js/js_util.dart';
 
 import 'navigation_params.dart';
 import 'router.dart';
@@ -83,7 +84,9 @@ class _RouterJs {
               navigationParams == null
                   ? null
                   : new NavigationParams(
-                      queryParameters: _objToMap(navigationParams['queryParameters']) ?? const {},
+                      queryParameters:
+                          _objToMap(navigationParams['queryParameters']) ??
+                              const {},
                       fragment: navigationParams['fragment'] ?? '',
                       updateUrl: navigationParams['updateUrl'] ?? true))
           .then((result) => callBack.callMethod('onCompletion', [result]));
@@ -126,10 +129,9 @@ class _NavigationParamsJs {
   external bool get updateUrl;
 }
 
-Map _objToMap(o) => o == null ? o : new Map.fromIterable(_jsKeys(o), value: (key) => _jsGetProp(o, key));
-
-@JS('Object.getProperty')
-external List<String> _jsGetProp(jsObject, key);
+Map _objToMap(o) => o == null
+    ? o
+    : new Map.fromIterable(_jsKeys(o), value: (key) => getProperty(o, key));
 
 @JS('Object.keys')
 external List<String> _jsKeys(jsObject);


### PR DESCRIPTION
Fixes #654, and possibly #635 too. (I haven't ran the main angular_router tests so I don't know if they are impacted by this.)

cc @kwalrath @alorenzen 