### PR TITLE
Fix warning in router_test.dart by adding a missing generic type.

### DIFF
--- a/angular_router/example/test/router_test.dart
+++ b/angular_router/example/test/router_test.dart
@@ -14,7 +14,7 @@ import 'package:angular_test/angular_test.dart';
 
 void main() {
   group('$Router', () {
-    NgTestFixture fixture;
+    NgTestFixture<TestRouter> fixture;
     AppComponentPO pageObject;
     Router router;
 


### PR DESCRIPTION
Fix warning in router_test.dart by adding a missing generic type.