### PR TITLE
Fix the generator_inputs optimization.

### DIFF
--- a/angular/lib/src/source_gen/template_compiler/template_processor.dart
+++ b/angular/lib/src/source_gen/template_compiler/template_processor.dart
@@ -18,6 +18,8 @@ Future<TemplateCompilerOutputs> processTemplates(
   final templateCompiler = createTemplateCompiler(buildStep, flags);
   final resolver = buildStep.resolver;
   final reflectables = await new ReflectableReader(
+    generatorInputs: flags.generatorInputs,
+
     // For a given import or export directive, return whether we have the
     // Dart file's URI in our inputs (for Bazel, it will be in the srcs =
     // [ ... ]).

--- a/angular/lib/src/transform/transformer.dart
+++ b/angular/lib/src/transform/transformer.dart
@@ -22,8 +22,9 @@ class AngularTransformerGroup extends TransformerGroup {
         )
       ],
     ];
-    phases =
-        phases.map((phase) => phase.map((t) => new EagerTransformerWrapper(t)));
+    phases = phases.map(
+      (phase) => phase.map((t) => new EagerTransformerWrapper(t)),
+    );
     return new AngularTransformerGroup._(phases);
   }
 

--- a/angular_compiler/lib/src/analyzer/reflector.dart
+++ b/angular_compiler/lib/src/analyzer/reflector.dart
@@ -238,8 +238,12 @@ class ReflectableReader {
     // "lib/some_file.dart" instead of "package:some_lib/some_file.dart".
     final from = new AssetId.resolve(fromUri);
     final source = new AssetId.resolve(sourceUri, from: from);
-    return source.package == from.package &&
+    final result = source.package == from.package &&
         generatorInputs.any((glob) => glob.matches(source.path));
+    if (result) {
+      log.fine('Avoiding a lookup on $source (matched generator_inputs)');
+    }
+    return result;
   }
 
   bool _shouldRecordFactory(ClassElement element) =>

--- a/angular_compiler/lib/src/flags.dart
+++ b/angular_compiler/lib/src/flags.dart
@@ -98,7 +98,7 @@ class CompilerFlags {
   const CompilerFlags({
     @required this.genDebugInfo,
     this.entryPoints: const [],
-    this.generatorInputs: const [],
+    this.generatorInputs,
     this.profileFor: Profile.none,
     this.useLegacyStyleEncapsulation: false,
     this.usePlaceholder: true,
@@ -227,7 +227,7 @@ class CompilerFlags {
           ? defaultTo.entryPoints
           : (entryPoints as Iterable<String>).map((e) => new Glob(e)).toList(),
       generatorInputs: generatorInputs == null
-          ? defaultTo.entryPoints
+          ? defaultTo.generatorInputs
           : (generatorInputs as Iterable<String>)
               .map((e) => new Glob(e))
               .toList(),


### PR DESCRIPTION
**DO NOT SUBMIT**: For testing only.

If it improves builds (it does for me locally), we'll release a 4.1 and update `angular_compiler`.

To try it, clone/fetch this PR, and add the following:

```yaml
dependency_overrides:
  angular:
    path: ../angular/angular
  angular_compiler:
    path: ../angular/angular_compiler
```

When running `pub serve -v` you should see something like:

`Avoiding a lookup on angular|lib/src/core/security.dart (matched generator_inputs)`

... many many times.

/cc @kevmoo 