### PR TITLE
[angular_test] Support use of external pub serve

### DIFF
--- a/angular_test/CHANGELOG.md
+++ b/angular_test/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unpublished
+
+- Add support for the use of an externally launched `pub serve` by
+  using "none" as the value of `--experimental-serve-script`.
+
 ## 1.0.2-alpha+1
 
 -   Use the new generic function syntax, stop using `package:func`.

--- a/angular_test/lib/src/bin/runner.dart
+++ b/angular_test/lib/src/bin/runner.dart
@@ -30,6 +30,22 @@ Future<Null> run(List<String> args) async {
     initFileWriting(logFile.openWrite());
   }
 
+  if (options.serveBin == 'none') {
+    const portArgPrefix = '--port=';
+    final portArg =
+        options.serveArgs.firstWhere((arg) => arg.startsWith('--port='));
+    if (portArg == null)
+      throw new ArgumentError.value(
+          'Specify external server port; e.g. --port=8081');
+    final port = int.parse(
+      portArg.substring(portArgPrefix.length),
+      onError: (_) => throw new ArgumentError.value(portArg, 'port'),
+    );
+    log('Using external server running on port $port.\nRunning tests...');
+    exitCode = await _runTests(options, port);
+    return;
+  }
+
   Process serveProcess;
 
   void killPub() {

--- a/angular_test/pubspec.yaml
+++ b/angular_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular_test
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Testing runner and library for AngularDart
-version: 1.0.2-alpha+2-dev
+version: 1.0.2-alpha+1
 
 environment:
   sdk: '>=2.0.0-dev.3.0 <2.0.0'

--- a/angular_test/pubspec.yaml
+++ b/angular_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular_test
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Testing runner and library for AngularDart
-version: 1.0.2-alpha+1
+version: 1.0.2-alpha+2-dev
 
 environment:
   sdk: '>=2.0.0-dev.3.0 <2.0.0'


### PR DESCRIPTION
Support is added w/o creating new command line flags. To have angular_test use an external pub serve (rather than launch its own) use "none" as the value of `--experimental-serve-script`; specify the external server port using `--port`. E.g.:

```shell
pub run angular_test --experimental-serve-script=none --port=8081 ...
```

Fixes #469