### PR TITLE
Prevents router from navigating twice when browser initiates navigation

### DIFF
--- a/_tests/test/common/directives/for_test.dart
+++ b/_tests/test/common/directives/for_test.dart
@@ -651,7 +651,7 @@ class NgForCustomTemplateNullTest {
 
 @Component(
     selector: 'test-cmp',
-    template: '<ul><template ngFor let-item [ngForOf]="items"'
+    template: '<ul><template ngFor let-item [ngForOf]="items" '
         '[ngForTemplate]="contentTpl" let-i="index">'
         '{{i}}: {{item}};</template></ul>',
     directives: const [NgFor])
@@ -672,7 +672,7 @@ class NgForCustomTemplatePrecedenceTest {
 
 @Component(
     selector: 'test-cmp',
-    template: '<ul><template ngFor let-item [ngForOf]="items"'
+    template: '<ul><template ngFor let-item [ngForOf]="items" '
         '[ngForTemplate]="contentTpl" let-i="index">'
         '{{i}}=> {{item}};</template></ul>',
     directives: const [NgFor])

--- a/_tests/test/common/forms/directives_test.dart
+++ b/_tests/test/common/forms/directives_test.dart
@@ -297,13 +297,13 @@ void main() {
       test("should reexport new control properties", () {
         var newControl = new Control(null);
         controlDir.form = newControl;
-        controlDir.ngOnChanges({"form": new SimpleChange(control, newControl)});
+        controlDir.ngAfterChanges();
         checkProperties(newControl);
       });
       test("should set up validator", () {
         expect(control.valid, true);
         // this will add the required validator and recalculate the validity
-        controlDir.ngOnChanges({"form": new SimpleChange(null, control)});
+        controlDir.ngAfterChanges();
         expect(control.valid, false);
       });
     });

--- a/angular_ast/lib/src/exception_handler/exception_handler.dart
+++ b/angular_ast/lib/src/exception_handler/exception_handler.dart
@@ -3,12 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 library angular_ast.src.exceptions;
 
-import 'package:meta/meta.dart';
 import 'package:analyzer/error/error.dart';
+import 'package:meta/meta.dart';
 import 'package:quiver/core.dart';
 
-part 'exceptions.dart';
 part 'angular_parser_exception.dart';
+part 'exceptions.dart';
 
 abstract class ExceptionHandler {
   void handle(AngularParserException e);

--- a/angular_router/lib/src/location/hash_location_strategy.dart
+++ b/angular_router/lib/src/location/hash_location_strategy.dart
@@ -58,7 +58,6 @@ class HashLocationStrategy extends LocationStrategy {
   @override
   void onPopState(html.EventListener fn) {
     this._platformLocation.onPopState(fn);
-    this._platformLocation.onHashChange(fn);
   }
 
   String getBaseHref() {

--- a/angular_router/lib/src/location/path_location_strategy.dart
+++ b/angular_router/lib/src/location/path_location_strategy.dart
@@ -66,7 +66,6 @@ class PathLocationStrategy extends LocationStrategy {
   @override
   void onPopState(html.EventListener fn) {
     _platformLocation.onPopState(fn);
-    _platformLocation.onHashChange(fn);
   }
 
   String getBaseHref() => _baseHref;


### PR DESCRIPTION
Prevents router from navigating twice when browser initiates navigation

Currently, the router listens to both `popstate` and `hashchange` events to
trigger navigation. When using `HashLocationStrategy`, changing the URL
fragment manually or pressing the back/forward buttons causes the router to
attempt navigating twice, as both actions trigger both events.

Normally, the first event would trigger a navigation and update the browser
location before the second event was handled. This would prevent the second
event from trigerring another navigation, since the browser location would
match the target location. However, delaying the first navigation by using
`await` in `CanActivate` stops the location from updating in time to prevent
the second navigation.