### PR TITLE
github sync

### DIFF
--- a/_goldens/test_files/deferred/container_component.template_debug.golden
+++ b/_goldens/test_files/deferred/container_component.template_debug.golden
@@ -77,10 +77,7 @@ class ViewTestContainerComponent0
     TemplateRef _TemplateRef_1_5 =
         new TemplateRef(_appEl_1, viewFactory_TestContainerComponent1);
     loadDeferred(
-        deflib0.loadLibrary, deflib1.loadLibrary, _appEl_1, _TemplateRef_1_5,
-        () {
-      deflib1.initReflector();
-    });
+        deflib0.loadLibrary, deflib1.loadLibrary, _appEl_1, _TemplateRef_1_5);
     var _anchor_2 = ngAnchor.clone(false);
     parentRenderNode.append(_anchor_2);
     dbgElm(this, _anchor_2, 2, 2, 6);
@@ -88,10 +85,7 @@ class ViewTestContainerComponent0
     TemplateRef _TemplateRef_2_5 =
         new TemplateRef(_appEl_2, viewFactory_TestContainerComponent2);
     loadDeferred(
-        deflib2.loadLibrary, deflib3.loadLibrary, _appEl_2, _TemplateRef_2_5,
-        () {
-      deflib3.initReflector();
-    });
+        deflib2.loadLibrary, deflib3.loadLibrary, _appEl_2, _TemplateRef_2_5);
     init(const [], null, [_text_0, _anchor_1, _anchor_2]);
     return null;
   }

--- a/_goldens/test_files/deferred/container_component.template_release.golden
+++ b/_goldens/test_files/deferred/container_component.template_release.golden
@@ -61,20 +61,14 @@ class ViewTestContainerComponent0
     TemplateRef _TemplateRef_1_5 =
         new TemplateRef(_appEl_1, viewFactory_TestContainerComponent1);
     loadDeferred(
-        deflib0.loadLibrary, deflib1.loadLibrary, _appEl_1, _TemplateRef_1_5,
-        () {
-      deflib1.initReflector();
-    });
+        deflib0.loadLibrary, deflib1.loadLibrary, _appEl_1, _TemplateRef_1_5);
     var _anchor_2 = ngAnchor.clone(false);
     parentRenderNode.append(_anchor_2);
     _appEl_2 = new ViewContainer(2, null, this, _anchor_2);
     TemplateRef _TemplateRef_2_5 =
         new TemplateRef(_appEl_2, viewFactory_TestContainerComponent2);
     loadDeferred(
-        deflib2.loadLibrary, deflib3.loadLibrary, _appEl_2, _TemplateRef_2_5,
-        () {
-      deflib3.initReflector();
-    });
+        deflib2.loadLibrary, deflib3.loadLibrary, _appEl_2, _TemplateRef_2_5);
     init(const [], null);
     return null;
   }

--- a/_tests/test/compiler/ast_template_parser_test.dart
+++ b/_tests/test/compiler/ast_template_parser_test.dart
@@ -1474,7 +1474,22 @@ void main() {
               ['template', 1],
               ['b', null]
             ]);
-      }, skip: 'Don\'t yet handle inline templates.');
+      });
+
+      test('should not match the element when there is a explicit template',
+          () {
+        expect(
+            humanizeContentProjection(
+                parse('<div><template [ngIf]="cond"><b></b></template></div>', [
+              createComp('div', ['a', 'b']),
+              ngIf
+            ])),
+            [
+              ['div', null],
+              ['template', null],
+              ['b', null]
+            ]);
+      });
 
       group('ngProjectAs', () {
         test('should override <ng-content>', () {

--- a/_tests/test/di/injector_test.dart
+++ b/_tests/test/di/injector_test.dart
@@ -237,12 +237,35 @@ void main() {
     });
 
     group('.generate', () {
+      final injector = exampleGenerated();
+
       test('should support "useClass"', () {
-        final injector = exampleGenerated();
         expect(
           injector.get(ExampleService),
           const isInstanceOf<ExampleService2>(),
         );
+      });
+
+      group('should support "useValue" to a', () {
+        test('boolean', () {
+          expect(injector.get(booleanToken), true);
+        });
+
+        test('number', () {
+          expect(injector.get(numberToken), 1234);
+        });
+
+        test('string', () {
+          expect(injector.get(stringToken), 'Hello World');
+        });
+      });
+
+      test('should return null when the binding failed', () {
+        // TODO(matanl): Remove this test once Injector.generated is stable.
+        // We are keeping this behavior to just allow incremental use of the API
+        // for EAPs, but at the same time be able to easily identify what
+        // scenario is not yet covered.
+        expect(() => injector.get(simpleConstToken), throwsUnimplementedError);
       });
     });
   });
@@ -264,12 +287,23 @@ class CaptureInjectInjector extends Injector {
   }
 }
 
-class ExampleService {}
+class ExampleService {
+  const ExampleService();
+}
 
 class ExampleService2 implements ExampleService {}
 
+const stringToken = const OpaqueToken('stringToken');
+const numberToken = const OpaqueToken('numberToken');
+const booleanToken = const OpaqueToken('booleanToken');
+const simpleConstToken = const OpaqueToken('simpleConstToken');
+
 @Injector.generate(const [
   const Provider(ExampleService, useClass: ExampleService2),
+  const Provider(stringToken, useValue: 'Hello World'),
+  const Provider(numberToken, useValue: 1234),
+  const Provider(booleanToken, useValue: true),
+  const Provider(simpleConstToken, useValue: const ExampleService()),
 ])
 Injector exampleGenerated() => ng.exampleGenerated$Injector();
 

--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -35,6 +35,18 @@ void main() {
 }
 ```
 
+*    Use of the template annotation `@deferred` does not work out of the box
+     with the standard bootstrap process (`bootstrap/bootstrapStatic`), only
+     the experimental `bootstrapFactory`. We've added a backwards compatible
+     compiler flag, `fast_boot`, that may be changed to `false`. We don't
+     expect this to impact most users.
+
+```yaml
+transformers:
+  angular:
+    fast_boot: false
+```
+
 ### Bug fixes
 
 *   Fixed a bug where errors thrown in event listeners were sometimes uncaught

--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.0.0-alpha+2
+
 ### Breaking changes
 
 *   Replaced `Visibility.none` with `Visibility.local`. The former name is

--- a/angular/lib/src/compiler/ast_template_parser.dart
+++ b/angular/lib/src/compiler/ast_template_parser.dart
@@ -250,7 +250,24 @@ class _BindDirectivesVisitor
 
   int _findNgContentIndexForTemplate(
       ast.EmbeddedTemplateAst astNode, _ParseContext context) {
+    if (_isInlineTemplate(astNode)) {
+      return _findNgContentIndexForElement(
+          astNode.childNodes
+              .firstWhere((childNode) => childNode is ast.ElementAst),
+          context);
+    }
     return context.findNgContentIndex(_templateSelector(astNode));
+  }
+
+  bool _isInlineTemplate(ast.EmbeddedTemplateAst astNode) {
+    if (astNode is! ast.SyntheticTemplateAst) return false;
+    final syntheticNode = astNode as ast.SyntheticTemplateAst;
+    if (syntheticNode.origin is ast.EmbeddedTemplateAst) {
+      return _isInlineTemplate(syntheticNode.origin);
+    }
+    if (syntheticNode.origin is ast.StarAst ||
+        syntheticNode.origin is ast.AttributeAst) return true;
+    return false;
   }
 
   @override

--- a/angular/lib/src/compiler/view_compiler/compile_element.dart
+++ b/angular/lib/src/compiler/view_compiler/compile_element.dart
@@ -443,16 +443,26 @@ class CompileElement extends CompileNode {
     var templateRefExpr =
         _instances.get(identifierToken(Identifiers.TemplateRef));
 
-    var initializerExpr = new o.FunctionExpr(const [], <o.Statement>[
-      o.importDeferred(templateInitializer).callFn(const []).toStmt()
-    ], null);
+    final args = [
+      o.importDeferred(prefixedId),
+      o.importDeferred(templatePrefixId),
+      viewContainerExpr,
+      templateRefExpr,
+    ];
+
+    // If "fastBoot" is not being used, we need to emit more information.
+    if (!view.genConfig.useFastBoot) {
+      final initReflectorExpr = new o.FunctionExpr(const [], <o.Statement>[
+        o.importDeferred(templateInitializer).callFn(const []).toStmt()
+      ], null);
+      args.add(initReflectorExpr);
+    }
 
     stmts.add(new o.InvokeMemberMethodExpr('loadDeferred', [
       o.importDeferred(prefixedId),
       o.importDeferred(templatePrefixId),
       viewContainerExpr,
       templateRefExpr,
-      initializerExpr
     ]).toStmt());
   }
 

--- a/angular/lib/src/compiler/view_compiler/compile_view.dart
+++ b/angular/lib/src/compiler/view_compiler/compile_view.dart
@@ -1,12 +1,12 @@
 import 'package:source_span/source_span.dart';
 import 'package:angular/src/core/change_detection/change_detection.dart'
     show ChangeDetectionStrategy;
-import "package:angular/src/core/metadata/view.dart" show ViewEncapsulation;
 import 'package:angular/src/core/linker/view_type.dart' show ViewType;
-import 'package:angular_compiler/angular_compiler.dart';
+import "package:angular/src/core/metadata/view.dart" show ViewEncapsulation;
 import 'package:angular/src/facade/exceptions.dart' show BaseException;
 import 'package:angular/src/transform/common/names.dart'
     show toTemplateExtension;
+import 'package:angular_compiler/angular_compiler.dart';
 
 import '../compile_metadata.dart'
     show
@@ -16,7 +16,6 @@ import '../compile_metadata.dart'
         CompileProviderMetadata,
         CompileQueryMetadata,
         CompileTokenMap;
-
 import '../identifiers.dart';
 import '../output/output_ast.dart' as o;
 import '../template_ast.dart'
@@ -28,12 +27,12 @@ import '../template_ast.dart'
         ProviderAst,
         ProviderAstType,
         VariableAst;
-import 'constants.dart' show parentRenderNodeVar;
 import 'compile_binding.dart' show CompileBinding;
 import 'compile_element.dart' show CompileElement, CompileNode;
 import 'compile_method.dart' show CompileMethod;
 import 'compile_pipe.dart' show CompilePipe;
 import 'compile_query.dart' show CompileQuery, addQueryToTokenMap;
+import 'constants.dart' show parentRenderNodeVar;
 import 'constants.dart' show appViewRootElementName, ViewProperties;
 import 'view_compiler_utils.dart'
     show

--- a/angular/lib/src/core/linker/app_view.dart
+++ b/angular/lib/src/core/linker/app_view.dart
@@ -628,14 +628,17 @@ abstract class AppView<T> {
   }
 
   Future<Null> loadDeferred(
-      Future loadComponentFunction(),
-      Future loadTemplateLibFunction(),
-      ViewContainer viewContainer,
-      TemplateRef templateRef,
-      void initializer()) {
+    Future loadComponentFunction(),
+    Future loadTemplateLibFunction(),
+    ViewContainer viewContainer,
+    TemplateRef templateRef, [
+    void initializer(),
+  ]) {
     return Future
         .wait([loadComponentFunction(), loadTemplateLibFunction()]).then((_) {
-      initializer();
+      if (initializer != null) {
+        initializer();
+      }
       viewContainer.createEmbeddedView(templateRef);
       viewContainer.detectChangesInNestedViews();
     });

--- a/angular/lib/src/debug/debug_app_view.dart
+++ b/angular/lib/src/debug/debug_app_view.dart
@@ -156,13 +156,19 @@ class DebugAppView<T> extends AppView<T> {
 
   @override
   Future<Null> loadDeferred(
-      Future loadComponentFunction(),
-      Future loadTemplateLibFunction(),
-      ViewContainer viewContainer,
-      TemplateRef templateRef,
-      void initializer()) {
-    var load = super.loadDeferred(loadComponentFunction,
-        loadTemplateLibFunction, viewContainer, templateRef, initializer);
+    Future loadComponentFunction(),
+    Future loadTemplateLibFunction(),
+    ViewContainer viewContainer,
+    TemplateRef templateRef, [
+    void initializer(),
+  ]) {
+    var load = super.loadDeferred(
+      loadComponentFunction,
+      loadTemplateLibFunction,
+      viewContainer,
+      templateRef,
+      initializer,
+    );
     deferredLoads.add(load);
     return load;
   }

--- a/angular/pubspec.yaml
+++ b/angular/pubspec.yaml
@@ -1,5 +1,5 @@
 name: angular
-version: 5.0.0-alpha+1
+version: 5.0.0-alpha+2
 author: Dart Team <web@dartlang.org>
 description: Fast and productive web framework
 homepage: https://webdev.dartlang.org/angular
@@ -8,8 +8,8 @@ environment:
   sdk: '>=2.0.0-dev.3.0 <2.0.0'
 dependencies:
   analyzer: '^0.31.0-alpha.1'
-  angular_ast: ^0.4.0-alpha+2
-  angular_compiler: ^0.4.0-alpha+1
+  angular_ast: ^0.4.0
+  angular_compiler: ^0.4.0-alpha+2
   barback: ^0.15.2+2
   build: '>=0.10.0 <0.12.0'
   build_barback: ^0.4.0

--- a/angular_ast/CHANGELOG.md
+++ b/angular_ast/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0
+
+First stable release in a while! Going forward we'll be versioning this package
+normally as needed to support the AngularDart template compiler and analyzer
+plugin.
+
 ### New features
 
 - Add `RecursiveTemplateAstVisitor`, which will visit all AST nodes accessible
@@ -5,6 +11,7 @@
 - Support `ngProjectAs` decorator on `<ng-content>`.
 
 ### Bug fixes
+
 - `DesugarVisitor` now desugars AST nodes which were the (indirect) children of
   `EmbeddedTemplateAst` nodes.
 

--- a/angular_ast/pubspec.yaml
+++ b/angular_ast/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular_ast
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Parser and utilities for AngularDart templates
-version: 0.4.0-alpha.1
+version: 0.4.0
 
 environment:
   sdk: '>=2.0.0-dev.3.0 <2.0.0'

--- a/angular_compiler/CHANGELOG.md
+++ b/angular_compiler/CHANGELOG.md
@@ -1,3 +1,4 @@
+* `CompilerFlags` now supports as a `fast_boot` argument; default is `true`.
 * `ReflectorEmitter` now takes an optional `deferredModules{Source}`.
 
 ## 0.4.0-alpha+1

--- a/angular_compiler/CHANGELOG.md
+++ b/angular_compiler/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.0-alpha+2
+
 * `CompilerFlags` now supports as a `fast_boot` argument; default is `true`.
 * `ReflectorEmitter` now takes an optional `deferredModules{Source}`.
 

--- a/angular_compiler/lib/src/emitter/injector.dart
+++ b/angular_compiler/lib/src/emitter/injector.dart
@@ -52,7 +52,7 @@ class InjectorEmitter implements InjectorVisitor {
   Method createInjectSelfOptional() => new Method((b) => b
     ..name = 'injectFromSelfOptional'
     ..returns = _$Object
-    ..annotations.add(_$override.annotation())
+    ..annotations.add(_$override)
     ..requiredParameters.add(new Parameter((b) => b
       ..name = 'token'
       ..type = _$Object))

--- a/angular_compiler/pubspec.yaml
+++ b/angular_compiler/pubspec.yaml
@@ -31,4 +31,6 @@ dependency_overrides:
   analyzer: '^0.31.0-alpha.1'
   angular:
     path: ../angular
+  angular_ast:
+      path: ../angular_ast
 # === ^^^ REMOVE WHEN PUBLISHING ^^^ ===

--- a/angular_compiler/pubspec.yaml
+++ b/angular_compiler/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular_compiler
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Compiler for AngularDart.
-version: 0.4.0-alpha+1
+version: 0.4.0-alpha+2
 
 environment:
   sdk: '>=2.0.0-dev.3.0 <2.0.0'
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies:
   # This is here in order for it to be resolvable by the analyzer.
-  angular: '^4.0.0-alpha'
+  angular: '^5.0.0-alpha'
   build_test: ^0.9.0
   test: '^0.12.0'
 

--- a/angular_forms/CHANGELOG.md
+++ b/angular_forms/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1-alpha+2
+
+_Maintenence release, to support the latest package:angular alpha._
+
 ## 1.0.1-alpha+1
 
 -   Use the new generic function syntax, stop using `package:func`.

--- a/angular_forms/pubspec.yaml
+++ b/angular_forms/pubspec.yaml
@@ -2,13 +2,13 @@ name: angular_forms
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Forms framework for AngularDart.
-version: 1.0.1-alpha+1
+version: 1.0.1-alpha+2
 
 environment:
   sdk: '>=2.0.0-dev.3.0 <2.0.0'
 
 dependencies:
-  angular: '^5.0.0-alpha+1'
+  angular: '^5.0.0-alpha+2'
   meta: ^1.0.3
 
 # === vvv REMOVE WHEN PUBLISHING vvv ===

--- a/angular_router/CHANGELOG.md
+++ b/angular_router/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.0-alpha+2
+
 - Fixed a bug where `RouterLinkDirective` was not keyboard accessible.
 
 ## 2.0.0-alpha+1

--- a/angular_router/pubspec.yaml
+++ b/angular_router/pubspec.yaml
@@ -2,20 +2,20 @@ name: angular_router
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Router for AngularDart.
-version: 2.0.0-alpha+1
+version: 2.0.0-alpha+2
 
 environment:
   sdk: '>=2.0.0-dev.3.0 <2.0.0'
 
 dependencies:
-  angular: '^5.0.0-alpha+1'
+  angular: '^5.0.0-alpha+2'
   collection: '^1.12.0'
   js: ^0.6.0
   meta: ^1.0.3
   quiver: '>=0.22.0 <0.26.0'
 
 dev_dependencies:
-  angular_test: ^1.0.1
+  angular_test: ^2.0.0-alpha
   build_compilers: ^0.1.0
   build_runner: ^0.6.1
   build_test: ^0.9.0

--- a/angular_test/CHANGELOG.md
+++ b/angular_test/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Unpublished
+## 2.0.0-alpha
+
+> **NOTE**: This was previously `1.0.2-alpha+1`, but since this has major
+> breaking changes that make it incompatible with the `1.x.x` releases in order
+> to support `angular 5.x.x`, this will now be the `2.0.0` alpha release.
 
 - Add support for the use of an externally launched `pub serve` by
   using "none" as the value of `--experimental-serve-script`.

--- a/angular_test/pubspec.yaml
+++ b/angular_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular_test
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Testing runner and library for AngularDart
-version: 1.0.2-alpha+1
+version: 2.0.0-alpha
 
 environment:
   sdk: '>=2.0.0-dev.3.0 <2.0.0'
@@ -11,7 +11,7 @@ executables:
   angular_test:
 
 dependencies:
-  angular: '^5.0.0-alpha+1'
+  angular: '^5.0.0-alpha+2'
   ansicolor: '^0.0.9'
   args: '^0.13.7'
   collection: '^1.14.0'

--- a/doc/compiler_flags.md
+++ b/doc/compiler_flags.md
@@ -2,7 +2,7 @@
 
 The following is a list of supported flags when using the AngularDart compiler
 as a _pub/barback transformer_. Any flag you don't see listed below is not
-supported in AngularDart 4.x, and will cause the compiler to fail.
+supported in AngularDart 5.x, and will cause the compiler to fail.
 
 Additionally, you can use the `mode` flag (to pub) to force a build compilation
 in `debug` mode (what is used for testing and local development). This can be
@@ -28,18 +28,17 @@ component.
 
 Defaults to `false`.
 
-## `entry_points`
+## `fast_boot`
 
 ```yaml
 transformers:
   angular:
-    entry_points:
-      - web/main.dart
+    fast_boot: false
 ```
 
-Entrypoint(s) of the application (i.e. where `bootstrap` is invoked or a
-`*_test.dart` file that uses `angular_test`). Build systems that re-write files
-(such as pub/barback) transform calls to `bootstrap` to `bootstrapStatic` and
-initialize code required to run AngularDart applications and tests.
+By disabling this flag, AngularDart may choose to generate additional code to
+support legacy classes like `SlowComponentLoader` and `ReflectiveInjector`. If
+you are using `fastBoot` (formally known as `bootstrapFactory`) then this can
+always safely be `true`.
 
-These may be written as a glob format (such as `lib/web/main_*.dart`).
+Defaults to `true` in AngularDart ^5.0.0-alpha+2.


### PR DESCRIPTION
feat(Compiler): Better warnings when @Injector.generate is used unsupported.

For EAPs, we want them to be able to use @Injector.generate for almost every type of provider, with a workaround today that "useFactory" is required in many cases where "useValue" worked previously.