### PR TITLE
Adds `Visibility.all` as the default visibility

### DIFF
--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -62,6 +62,12 @@ transformers:
 *   Fixed a bug where an `@deferred` components were still being linked to in
     `initReflector()`.
 
+### Refactors
+
+*   Added `Visibility.all` as the default visibility of all directives. This has
+    no user-facing implications yet, but will allow migrating the default from
+    `Visibility.all` to `Visibility.local`.
+
 ## 5.0.0-alpha+1
 
 **NOTE**: As of `angular 5.0.0-alpha+1` [`dependency_overrides`][dep_overrides] are **required**:

--- a/angular/lib/src/compiler/compile_metadata.dart
+++ b/angular/lib/src/compiler/compile_metadata.dart
@@ -97,7 +97,7 @@ class CompileProviderMetadata {
     this.useExisting,
     this.useFactory,
     this.deps,
-    this.visibility,
+    this.visibility: Visibility.all,
     bool multi,
     this.multiType,
   })
@@ -450,7 +450,7 @@ class CompileDirectiveMetadata implements CompileMetadataWithType {
     this.hostAttributes,
     this.analyzedClass,
     this.template,
-    this.visibility,
+    this.visibility: Visibility.all,
     List<LifecycleHooks> lifecycleHooks,
     // CompileProviderMetadata | CompileTypeMetadata |
     // CompileIdentifierMetadata | List

--- a/angular/lib/src/compiler/provider_parser.dart
+++ b/angular/lib/src/compiler/provider_parser.dart
@@ -498,7 +498,7 @@ class _ProviderResolver {
           implementedByDirectiveWithNoVisibility:
               implementedByDirectiveWithNoVisibility,
           multiProviderType: provider.multiType,
-          visibleForInjection: provider.visibility == null,
+          visibleForInjection: provider.visibility == Visibility.all,
         );
         _providersByToken.add(provider.token, resolvedProvider);
       } else {

--- a/angular/lib/src/core/metadata/visibility.dart
+++ b/angular/lib/src/core/metadata/visibility.dart
@@ -19,4 +19,9 @@ enum Visibility {
   /// In this example, `PrivateImplementation` can't be injected directly, but
   /// it will be provided to satisfy a dependency on `PublicDependency`.
   local,
+
+  /// Can be injected anywhere in the subtree rooted where this is provided.
+  ///
+  /// This is the default visibility and need not be explicitly set.
+  all,
 }

--- a/angular/lib/src/source_gen/template_compiler/find_components.dart
+++ b/angular/lib/src/source_gen/template_compiler/find_components.dart
@@ -546,8 +546,12 @@ class ComponentVisitor
       queries: _queries,
       viewQueries: _viewQueries,
       template: template,
-      visibility:
-          coerceEnum(annotationValue, _visibilityProperty, Visibility.values),
+      visibility: coerceEnum(
+        annotationValue,
+        _visibilityProperty,
+        Visibility.values,
+        defaultTo: Visibility.all,
+      ),
     );
   }
 


### PR DESCRIPTION
Adds `Visibility.all` as the default visibility

This is equivalent to previously having null visilibty, and is being added to
prepare for switching the default from `all` to `local`.