### PR TITLE
fix(Core): ReflectiveInjector now throws, and doesn't return Object, on fail.

### DIFF
--- a/_tests/test/regression/755_reflective_meta_fail_test.dart
+++ b/_tests/test/regression/755_reflective_meta_fail_test.dart
@@ -1,0 +1,32 @@
+@Tags(const ['codegen'])
+@TestOn('browser')
+
+import 'package:test/test.dart';
+import 'package:angular/angular.dart';
+
+import '755_reflective_meta_fail_test.template.dart' as ng_generated;
+
+// Source: https://github.com/dart-lang/angular/issues/755.
+void main() {
+  ng_generated.initReflector();
+
+  test('should throw ArgumentError on a missing provider', () {
+    final injector = new Injector.slowReflective([
+      const Provider(ServiceInjectingToken, useClass: ServiceInjectingToken),
+      // Intentionally omit a binding for "stringToken".
+    ]);
+
+    // Used to return an Object representing the secret "notFound" instead of
+    // throwing ArgumentError, which was the expected behavior.
+    expect(() => injector.get(ServiceInjectingToken), throwsArgumentError);
+  });
+}
+
+const stringToken = const OpaqueToken('stringToken');
+
+@Injectable()
+class ServiceInjectingToken {
+  final String tokenValue;
+
+  ServiceInjectingToken(@Inject(stringToken) this.tokenValue);
+}

--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Bug fixes
+
+*   Fixed a bug where `ReflectiveInjector` would return an `Object` instead of
+    throwing `ArgumentError` when resolving an `@Injectable()` service that
+    injected a dependency with one or more annotations (i.e. `@Inject(...)`).
+
 ## 5.0.0-alpha+2
 
 ### Breaking changes

--- a/angular/lib/src/di/injector/runtime.dart
+++ b/angular/lib/src/di/injector/runtime.dart
@@ -106,7 +106,13 @@ class _RuntimeInjector extends HierarchicalInjector
     final resolved = new List(deps.length);
     for (var i = 0, l = resolved.length; i < l; i++) {
       final dep = deps[i];
-      resolved[i] = dep is List ? _resolveMeta(dep) : inject(dep);
+      final result = dep is List ? _resolveMeta(dep) : inject(dep);
+      // We don't check to see if this failed otherwise, because this is an
+      // edge case where we just delegate to Function.apply to invoke a factory.
+      if (identical(result, throwIfNotFound)) {
+        return throwsNotFound(this, token);
+      }
+      resolved[i] = result;
     }
     return resolved;
   }


### PR DESCRIPTION
fix(Core): ReflectiveInjector now throws, and doesn't return Object, on fail.

In DDC, this would cause a TypeError, while in Dartium/Dart2JS a sentinel
Object value abstraction was returned instead of throwing ArgumentError.