### PR TITLE
Fix date_pipe handling of milliseconds

### DIFF
--- a/angular/lib/src/common/pipes/date_pipe.dart
+++ b/angular/lib/src/common/pipes/date_pipe.dart
@@ -84,7 +84,7 @@ class DatePipe implements PipeTransform {
       throw new InvalidPipeArgumentException(DatePipe, value);
     }
     if (value is num) {
-      value = new DateTime.fromMillisecondsSinceEpoch(value, isUtc: true);
+      value = new DateTime.fromMillisecondsSinceEpoch(value);
     }
     if (DatePipe._ALIASES.containsKey(pattern)) {
       pattern = DatePipe._ALIASES[pattern];


### PR DESCRIPTION
date_pipe erroneously was formatting int values as UTC timezones.