### PR TITLE
Up build version

### DIFF
--- a/angular/pubspec.yaml
+++ b/angular/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   analyzer: '>=0.29.10 <0.31.0'
   angular_compiler: ^0.3.0
   barback: ^0.15.2+2
-  build: ^0.10.0
+  build: '>=0.10.0 <0.12.0'
   build_barback: ^0.4.0
   code_builder: '^1.0.0-beta+4'
   collection: '^1.12.0'

--- a/angular_compiler/pubspec.yaml
+++ b/angular_compiler/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 dev_dependencies:
   # This is here in order for it to be resolvable by the analyzer.
   angular: '^4.0.0-alpha'
-  build_test: ^0.9.0
+  build_test: ^0.7.1
   test: '^0.12.0'
 
 # === vvv REMOVE WHEN PUBLISHING vvv ===

--- a/angular_compiler/pubspec.yaml
+++ b/angular_compiler/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   analyzer: '>=0.29.10 <0.31.0'
   args: '>=0.13.6 <2.0.0'
   barback: ^0.15.2+2
-  build: ^0.10.0
+  build: '>=0.10.0 <0.12.0'
   collection: ^1.8.0
   glob: ^1.0.0
   logging: '>=0.9.0 <0.12.0'
@@ -22,7 +22,7 @@ dependencies:
 dev_dependencies:
   # This is here in order for it to be resolvable by the analyzer.
   angular: '^4.0.0-alpha'
-  build_test: ^0.7.0
+  build_test: ^0.9.0
   test: '^0.12.0'
 
 # === vvv REMOVE WHEN PUBLISHING vvv ===


### PR DESCRIPTION
Our team recently began to build our application with the build_runner instead of the pub. We use version 0.6.1. But we can't release our new builder because we have an override for build v 0.11.0. This fix helps us to solve our problem