### PR TITLE
Attempt to de-lint the repository down where possible

### DIFF
--- a/_goldens/test_files/queries.dart
+++ b/_goldens/test_files/queries.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: deprecated_member_use
 import 'dart:html';
 import 'package:angular/angular.dart';
 

--- a/_tests/test/common/directives/ng_template_outlet_test.dart
+++ b/_tests/test/common/directives/ng_template_outlet_test.dart
@@ -116,7 +116,7 @@ void main() {
 @Directive(selector: "tpl-refs", exportAs: "tplRefs")
 class CaptureTplRefs {
   @ContentChildren(TemplateRef)
-  QueryList<TemplateRef> tplRefs;
+  List<TemplateRef> tplRefs;
 }
 
 @Component(

--- a/_tests/test/core/directive_inheritance_test.dart
+++ b/_tests/test/core/directive_inheritance_test.dart
@@ -266,10 +266,10 @@ class RootComponent {
   Stream<String> get output => _outputController.stream;
 
   @ContentChildren(QueryTargetComponent)
-  QueryList<QueryTargetComponent> contentChildren;
+  List<QueryTargetComponent> contentChildren;
 
   @ViewChildren(QueryTargetComponent)
-  QueryList<QueryTargetComponent> viewChildren;
+  List<QueryTargetComponent> viewChildren;
 
   void dispatchOutput(String outputData) {
     _outputController.add(outputData);
@@ -364,12 +364,12 @@ class AnnotatedDerivedComponent extends RootComponent {
   String get title => super.title;
 
   @ContentChildren('content')
-  set contentChildren(QueryList<QueryTargetComponent> value) {
+  set contentChildren(List<QueryTargetComponent> value) {
     super.contentChildren = value;
   }
 
   @ViewChildren('view')
-  set viewChildren(QueryList<QueryTargetComponent> value) {
+  set viewChildren(List<QueryTargetComponent> value) {
     super.viewChildren = value;
   }
 }

--- a/_tests/test/core/linker/dynamic_component_loader_test.dart
+++ b/_tests/test/core/linker/dynamic_component_loader_test.dart
@@ -196,6 +196,7 @@ class MyComp {
   bool ctxBoolProp;
   @ViewChild('loc', read: ViewContainerRef)
   ViewContainerRef viewContainerRef;
+  // ignore: deprecated_member_use
   final SlowComponentLoader loader;
   MyComp(this.loader) {
     this.ctxBoolProp = false;

--- a/_tests/test/core/linker/integration/template_test.dart
+++ b/_tests/test/core/linker/integration/template_test.dart
@@ -141,7 +141,7 @@ class ToolbarViewContainer {
 )
 class ToolbarComponent {
   @ContentChildren(ToolbarPart)
-  QueryList<ToolbarPart> query;
+  List<ToolbarPart> query;
 
   String prop = 'hello world';
 }

--- a/_tests/test/core/linker/query_integration_test.dart
+++ b/_tests/test/core/linker/query_integration_test.dart
@@ -7,6 +7,8 @@ import 'package:angular/angular.dart';
 
 import 'query_integration_test.template.dart' as ng_generated;
 
+// ignore_for_file: deprecated_member_use
+
 void main() {
   ng_generated.initReflector();
 

--- a/_tests/test/core/linker/query_list_test.dart
+++ b/_tests/test/core/linker/query_list_test.dart
@@ -3,6 +3,8 @@ import 'package:test/test.dart';
 import 'package:_tests/fake_async.dart';
 import 'package:angular/src/core/linker/query_list.dart' show QueryList;
 
+// ignore_for_file: deprecated_member_use
+
 void main() {
   group("QueryList", () {
     QueryList<String> queryList;

--- a/_tests/test/core/view/projection_integration_test.dart
+++ b/_tests/test/core/view/projection_integration_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 import 'package:angular/core.dart'
     show Component, Directive, Input, ViewChild, ViewChildren;
 import 'package:angular/src/core/linker.dart'
-    show ElementRef, QueryList, TemplateRef, ViewContainerRef;
+    show ElementRef, TemplateRef, ViewContainerRef;
 import 'package:angular/src/debug/debug_node.dart' show getAllDebugNodes;
 import 'package:angular_test/angular_test.dart';
 
@@ -304,7 +304,7 @@ class OnlyDirectChildrenTest {}
 )
 class LightDomChangeTest {
   @ViewChildren(ManualViewportDirective)
-  QueryList<ManualViewportDirective> viewports;
+  List<ManualViewportDirective> viewports;
 }
 
 @Component(
@@ -593,7 +593,7 @@ class ConditionalContentComponent {
 )
 class ConditionalTextComponent {
   @ViewChildren(ManualViewportDirective)
-  QueryList<ManualViewportDirective> viewports;
+  List<ManualViewportDirective> viewports;
 }
 
 @Component(

--- a/_tests/test/integration/query_content_test.dart
+++ b/_tests/test/integration/query_content_test.dart
@@ -42,7 +42,7 @@ void main() {
 class ContentChildrenComponent extends HasChildren<ValueDirective> {
   @override
   @ContentChildren(ValueDirective)
-  QueryList actualChildren;
+  List actualChildren;
 }
 
 @Component(
@@ -74,7 +74,7 @@ class TestContentChildren extends HasChildren<ValueDirective> {
   HasChildren<ValueDirective> content;
 
   @override
-  QueryList get actualChildren => content.actualChildren;
+  List get actualChildren => content.actualChildren;
 }
 
 @Component(

--- a/_tests/test/integration/query_view_test.dart
+++ b/_tests/test/integration/query_view_test.dart
@@ -101,7 +101,7 @@ void main() {
 class TestDirectViewChildren extends HasChildren<ValueDirective> {
   @override
   @ViewChildren(ValueDirective)
-  QueryList actualChildren;
+  List actualChildren;
 }
 
 @Component(
@@ -138,7 +138,7 @@ class TestDirectViewChild extends HasChild<ValueDirective> {
 class TestViewChildrenAndEmbedded extends HasChildren<ValueDirective> {
   @override
   @ViewChildren(ValueDirective)
-  QueryList actualChildren;
+  List actualChildren;
 }
 
 @Component(

--- a/angular/lib/di.dart
+++ b/angular/lib/di.dart
@@ -10,8 +10,8 @@ export 'src/core/metadata.dart' show Pipe;
 export 'src/core/zone/ng_zone.dart' hide WrappedTimer;
 // TODO: remove ExceptionHandler and WrappedException after deprecation.
 export 'src/facade/facade.dart'
-    // ignore: deprecated_member_use
     show
+        // ignore: deprecated_member_use
         EventEmitter,
         ExceptionHandler,
         WrappedException;

--- a/angular/lib/src/core/linker.dart
+++ b/angular/lib/src/core/linker.dart
@@ -4,10 +4,12 @@ export "linker/component_factory.dart" show ComponentRef, ComponentFactory;
 export "linker/component_loader.dart" show ComponentLoader;
 // ignore: deprecated_member_use
 export "linker/component_resolver.dart" show ComponentResolver;
+// ignore: deprecated_member_use
 export "linker/dynamic_component_loader.dart" show SlowComponentLoader;
 export "linker/element_ref.dart" show ElementRef;
 export "linker/exceptions.dart"
     show ExpressionChangedAfterItHasBeenCheckedException;
+// ignore: deprecated_member_use
 export "linker/query_list.dart" show QueryList;
 export "linker/template_ref.dart" show TemplateRef;
 export "linker/view_container_ref.dart" show ViewContainerRef;

--- a/angular/lib/src/di/injector/hierarchical.dart
+++ b/angular/lib/src/di/injector/hierarchical.dart
@@ -16,7 +16,6 @@ abstract class HierarchicalInjector extends Injector {
   const HierarchicalInjector([this.parent = const EmptyInjector()]);
 
   /// **INTERNAL ONLY**: Used to implement [EmptyInjector] efficiently.
-  @visibleForTesting
   const HierarchicalInjector.maybeEmpty([this.parent]);
 
   @override

--- a/angular_ast/lib/src/expression/visitor.dart
+++ b/angular_ast/lib/src/expression/visitor.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/src/dart/ast/utilities.dart';
-import 'package:analyzer/src/generated/java_core.dart';
 
 import 'ng_dart_ast.dart';
 
@@ -15,12 +14,12 @@ abstract class AngularDartAstVisitor<R> extends AstVisitor<R> {
 
 /// A visitor used to write a source representation of a visited AST node (and
 /// all of it's children) to a writer. This handles AngularDartAst nodes.
-class NgToSourceVisitor extends ToSourceVisitor
+class NgToSourceVisitor extends ToSourceVisitor2
     implements AngularDartAstVisitor<Object> {
-  final PrintWriter _writer;
+  final StringSink _writer;
 
   factory NgToSourceVisitor() {
-    final writer = new PrintStringWriter();
+    final writer = new StringBuffer();
     return new NgToSourceVisitor._(writer);
   }
 
@@ -28,13 +27,13 @@ class NgToSourceVisitor extends ToSourceVisitor
 
   @override
   Object visitPipeOptionalArgumentList(PipeOptionalArgumentList node) {
-    _writer.print(node.toSource());
+    _writer.write(node.toSource());
     return null;
   }
 
   @override
   Object visitPipeInvocation(PipeInvocationExpression node) {
-    _writer.print(node.toSource());
+    _writer.write(node.toSource());
     return null;
   }
 

--- a/angular_ast/lib/src/scanner.dart
+++ b/angular_ast/lib/src/scanner.dart
@@ -45,7 +45,7 @@ class NgScanner {
     Uri sourceUrl,
   }) {
     var reader = new NgTokenReversibleReader<NgSimpleTokenType>(
-        new SourceFile(html, url: sourceUrl),
+        new SourceFile.fromString(html, url: sourceUrl),
         new NgSimpleTokenizer().tokenize(html));
     var recoverError = exceptionHandler is RecoveringExceptionHandler;
 

--- a/angular_forms/lib/angular_forms.dart
+++ b/angular_forms/lib/angular_forms.dart
@@ -29,6 +29,7 @@ export 'src/directives.dart'
         NgControl,
         NgControlGroup,
         NgControlName,
+        // ignore: deprecated_member_use
         NgControlStatus,
         NgForm,
         NgFormControl,

--- a/angular_forms/lib/src/directives.dart
+++ b/angular_forms/lib/src/directives.dart
@@ -31,6 +31,7 @@ export 'directives/form_interface.dart' show Form;
 export 'directives/ng_control.dart' show NgControl;
 export 'directives/ng_control_group.dart' show NgControlGroup;
 export 'directives/ng_control_name.dart' show NgControlName;
+// ignore: deprecated_member_use
 export 'directives/ng_control_status.dart' show NgControlStatus;
 export 'directives/ng_form.dart' show NgForm;
 export 'directives/ng_form_control.dart' show NgFormControl;

--- a/angular_router/lib/src/route_definition.dart
+++ b/angular_router/lib/src/route_definition.dart
@@ -44,7 +44,6 @@ abstract class RouteDefinition {
   ///
   /// When assertions are enabled, throws [StateError]. Otherwise does nothing.
   @mustCallSuper
-  @visibleForTesting
   void assertValid() {
     assert(() {
       if (path == null) {
@@ -180,7 +179,6 @@ abstract class RouteDefinition {
 /// Returns a future that completes with a component type or factory.
 typedef Future<ComponentFactory> LoadComponentAsync();
 
-@visibleForTesting
 class ComponentRouteDefinition extends RouteDefinition {
   /// Allows creating a component imperatively.
   final ComponentFactory component;
@@ -213,7 +211,6 @@ class ComponentRouteDefinition extends RouteDefinition {
   }
 }
 
-@visibleForTesting
 class DeferredRouteDefinition extends RouteDefinition {
   /// Returns a future that completes with a component type to be resolved.
   final LoadComponentAsync loader;
@@ -243,7 +240,6 @@ class DeferredRouteDefinition extends RouteDefinition {
   }
 }
 
-@visibleForTesting
 class RedirectRouteDefinition extends RouteDefinition {
   /// What [path] to redirect to when resolved.
   final String redirectTo;

--- a/angular_router/lib/src/router/navigation_params.dart
+++ b/angular_router/lib/src/router/navigation_params.dart
@@ -42,7 +42,6 @@ class NavigationParams {
   ///
   /// When assertions are enabled, throws [StateError]. Otherwise does nothing.
   @mustCallSuper
-  @visibleForTesting
   void assertValid() {
     assert(() {
       if (fragment == null) {

--- a/angular_router/lib/src/router/router_outlet_token.dart
+++ b/angular_router/lib/src/router/router_outlet_token.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:meta/meta.dart';
 import 'package:angular/angular.dart';
 
 import '../directives/router_outlet_directive.dart';
@@ -13,7 +12,6 @@ import '../directives/router_outlet_directive.dart';
 /// angular component will initialize and it's [RouterOutlet] will also
 /// initialize. The RouterOutlet's constructor will then attach itself to the
 /// token, enabling the Router to have a point to the RouterOutlet.
-@visibleForTesting
 class RouterOutletToken {
   RouterOutlet routerOutlet;
 }


### PR DESCRIPTION
By ignoring known deprecations, removing some deprecated member use, and removing invalid uses of `@visibleForTesting` (where it had no effect anyway).