### PR TITLE
fix(Test): Golden file tests ignore ng_placeholder.

### DIFF
--- a/_goldens/generator/bin/generate.dart
+++ b/_goldens/generator/bin/generate.dart
@@ -27,19 +27,26 @@ Future main(List<String> args) async {
         'angular|goldens',
         [
           (_) => new LibraryBuilder(
-              new TemplateGenerator(
-                  const CompilerFlags(genDebugInfo: false, useAstPkg: true)),
+              new TemplateGenerator(const CompilerFlags(
+                  genDebugInfo: false,
+                  ignoreNgPlaceholderForGoldens: true,
+                  useAstPkg: true)),
               generatedExtension: updateGoldens
                   ? '.template_release.golden'
                   : '.template_release.check'),
           (_) => new LibraryBuilder(
-              new TemplateGenerator(
-                  const CompilerFlags(genDebugInfo: true, useAstPkg: true)),
+              new TemplateGenerator(const CompilerFlags(
+                  genDebugInfo: true,
+                  ignoreNgPlaceholderForGoldens: true,
+                  useAstPkg: true)),
               generatedExtension: updateGoldens
                   ? '.template_debug.golden'
                   : '.template_debug.check'),
           (_) => new TemplateOutliner(
-              const CompilerFlags(genDebugInfo: false, useAstPkg: true),
+              const CompilerFlags(
+                  genDebugInfo: false,
+                  ignoreNgPlaceholderForGoldens: true,
+                  useAstPkg: true),
               extension: updateGoldens
                   ? '.template_outline.golden'
                   : '.template_outline.check'),

--- a/angular/lib/src/source_gen/template_compiler/template_processor.dart
+++ b/angular/lib/src/source_gen/template_compiler/template_processor.dart
@@ -27,11 +27,17 @@ Future<TemplateCompilerOutputs> processTemplates(
     // a.dart, and a.dart imports b.dart, we can assume that there will be
     // a generated b.template.dart that we need to import/initReflector().
     hasInput: (uri) async {
+      if (flags.ignoreNgPlaceholderForGoldens) {
+        return buildStep.canRead(
+          new AssetId.resolve(uri, from: buildStep.inputId),
+        );
+      }
       final placeholder = ''
           '${uri.substring(0, uri.length - '.dart'.length)}'
           '.ng_placeholder';
-      return await buildStep
-          .canRead(new AssetId.resolve(placeholder, from: buildStep.inputId));
+      return buildStep.canRead(
+        new AssetId.resolve(placeholder, from: buildStep.inputId),
+      );
     },
     // For a given import or export directive, return whether a generated
     // .template.dart file already exists. If it does we will need to link

--- a/angular_compiler/lib/src/flags.dart
+++ b/angular_compiler/lib/src/flags.dart
@@ -77,12 +77,21 @@ class CompilerFlags {
   /// * polyfill-unscoped-rule
   final bool useLegacyStyleEncapsulation;
 
+  /// Whether to look for a file to determine if `.template.dart` will exist.
+  ///
+  /// **NOTE**: This is an _internal_ flag that is currently only supported for
+  /// use with the golden file testing, and may be removed at some point in the
+  /// future.
+  @experimental
+  final bool ignoreNgPlaceholderForGoldens;
+
   /// Whether to opt-in to using the new angular_ast package for parsing
   /// template files.
   final bool useAstPkg;
 
   const CompilerFlags({
     @required this.genDebugInfo,
+    this.ignoreNgPlaceholderForGoldens: false,
     this.profileFor: Profile.none,
     this.useFastBoot: true,
     this.useLegacyStyleEncapsulation: false,


### PR DESCRIPTION
fix(Test): Golden file tests ignore ng_placeholder.

I was a little too gung-ho on the cleanup, and removed a feature that golden files still rely on. We can chat with alorenzen@ when he gets back on whether we can remove this safely.