### PR TITLE
chore(Travis): Try removing --low-resources-mode

### DIFF
--- a/angular/lib/src/di/providers.dart
+++ b/angular/lib/src/di/providers.dart
@@ -6,8 +6,6 @@ import 'package:meta/meta.dart';
 
 import '../core/di/opaque_token.dart';
 
-var intentionallyInvalidateTheCache = true;
-
 /// A marker that represents a lack-of-value for the `useValue` parameter.
 const Object noValueProvided = '__noValueProvided__';
 

--- a/angular/lib/src/di/providers.dart
+++ b/angular/lib/src/di/providers.dart
@@ -6,6 +6,8 @@ import 'package:meta/meta.dart';
 
 import '../core/di/opaque_token.dart';
 
+var intentionallyInvalidateTheCache = true;
+
 /// A marker that represents a lack-of-value for the `useValue` parameter.
 const Object noValueProvided = '__noValueProvided__';
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -29,8 +29,8 @@ esac
 case $TASK in
 build) echo
   echo -e '\033[1mTASK: build\033[22m'
-  echo -e 'pub run build_runner build --low-resources-mode'
-  pub run build_runner build --low-resources-mode
+  echo -e 'pub run build_runner build'
+  pub run build_runner build
   ;;
 dartanalyzer_0) echo
   echo -e '\033[1mTASK: dartanalyzer_0\033[22m'


### PR DESCRIPTION
GCE-based containers (we use one now) have ~8Gb of Ram and 2 (Burstable) Cores:
https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System

We should see if we can remove `--low-resources-mode`, if possible.