### PR TITLE
GitHub Sync

### DIFF
--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 5.0.0-alpha+5
+
 ### New features
 
 * Enables the new template parser by default. This parser is much stricter than

--- a/angular/pubspec.yaml
+++ b/angular/pubspec.yaml
@@ -1,5 +1,5 @@
 name: angular
-version: 5.0.0-alpha+4
+version: 5.0.0-alpha+5
 author: Dart Team <web@dartlang.org>
 description: Fast and productive web framework
 homepage: https://webdev.dartlang.org/angular
@@ -18,8 +18,8 @@ dependencies:
 
   # Compiler. Eventually we want to move these to angular_compiler.
   analyzer: '^0.31.0+1'
-  angular_ast: ^0.4.0
-  angular_compiler: ^0.4.0-alpha+4
+  angular_ast: ^0.4.3
+  angular_compiler: ^0.4.0-alpha+5
   build: ^0.12.0+1
   code_builder: '^3.0.1'
   csslib: ^0.14.1

--- a/angular_ast/CHANGELOG.md
+++ b/angular_ast/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.3
+
+- Maintenance release, supporting newer package versions.
+
 ## 0.4.2
 
 - Supports the latest version of `quiver`.

--- a/angular_ast/pubspec.yaml
+++ b/angular_ast/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular_ast
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Parser and utilities for AngularDart templates
-version: 0.4.2
+version: 0.4.3
 
 environment:
   sdk: '>=2.0.0-dev.20.0 <2.0.0'

--- a/angular_compiler/CHANGELOG.md
+++ b/angular_compiler/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.0-alpha+5
+
 ### Bug fixes
 
 * `linkTypeOf` correctly resolves bound types (i.e. `<T>`) in most cases, and

--- a/angular_compiler/pubspec.yaml
+++ b/angular_compiler/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular_compiler
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Compiler for AngularDart.
-version: 0.4.0-alpha+4
+version: 0.4.0-alpha+5
 
 environment:
   sdk: '>=2.0.0-dev.20.0 <2.0.0'

--- a/angular_forms/CHANGELOG.md
+++ b/angular_forms/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1-alpha+5
+
+_Maintenance release, to support the latest package:angular alpha._
+
 ## 1.0.1-alpha+4
 
 _Maintenance release, to support the latest package:angular alpha._

--- a/angular_forms/pubspec.yaml
+++ b/angular_forms/pubspec.yaml
@@ -2,13 +2,13 @@ name: angular_forms
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Forms framework for AngularDart.
-version: 1.0.1-alpha+4
+version: 1.0.1-alpha+5
 
 environment:
-  sdk: '>=2.0.0-dev.3.0 <2.0.0'
+  sdk: '>=2.0.0-dev.20.0 <2.0.0'
 
 dependencies:
-  angular: '^5.0.0-alpha+4'
+  angular: '^5.0.0-alpha+5'
   meta: ^1.1.2
 
 # === vvv REMOVE WHEN PUBLISHING vvv ===

--- a/angular_router/CHANGELOG.md
+++ b/angular_router/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.0-alpha+5
+
 ### New features
 
 *   Added `Router.onNavigationStart` to notify subscribers when a navigation

--- a/angular_router/pubspec.yaml
+++ b/angular_router/pubspec.yaml
@@ -2,20 +2,20 @@ name: angular_router
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Router for AngularDart.
-version: 2.0.0-alpha+4
+version: 2.0.0-alpha+5
 
 environment:
   sdk: '>=2.0.0-dev.20.0 <2.0.0'
 
 dependencies:
-  angular: '^5.0.0-alpha+4'
+  angular: '^5.0.0-alpha+5'
   collection: ^1.14.5
   js: ^0.6.0
   meta: ^1.1.2
 
 dev_dependencies:
   async: ^2.0.3
-  angular_test: ^2.0.0-alpha+2
+  angular_test: ^2.0.0-alpha+3
   build_web_compilers: ^0.2.1
   build_runner: ^0.7.9
   build_test: ^0.10.0

--- a/angular_test/CHANGELOG.md
+++ b/angular_test/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.0-alpha+3
+
 * Removed support for `pub run angular_test`. This is no longer strictly
   needed, as it was just a convenience for running both the build system and
   test runner. Similar functionality is supported out of the box by

--- a/angular_test/pubspec.yaml
+++ b/angular_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: angular_test
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/angular
 description: Testing runner and library for AngularDart
-version: 2.0.0-alpha+2
+version: 2.0.0-alpha+3
 
 environment:
   sdk: '>=2.0.0-dev.20.0 <2.0.0'
@@ -12,7 +12,7 @@ executables:
   angular_test:
 
 dependencies:
-  angular: '^5.0.0-alpha+4'
+  angular: '^5.0.0-alpha+5'
   matcher: ^0.12.0+2
   meta: ^1.1.2
   pageloader: ^2.2.5

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -29,8 +29,8 @@ esac
 case $TASK in
 build) echo
   echo -e '\033[1mTASK: build\033[22m'
-  echo -e 'pub run build_runner build --low-resources-mode'
-  pub run build_runner build --low-resources-mode
+  echo -e 'pub run build_runner build'
+  pub run build_runner build
   ;;
 dartanalyzer_0) echo
   echo -e '\033[1mTASK: dartanalyzer_0\033[22m'


### PR DESCRIPTION
chore(Travis): Remove --low-resources-mode.

This made sense when we (a) didn't use `pub run test --precompiled` (spun up multiple VMs) and (b) didn't use the newer travis containers that have 2 CPUs and almost 8GB of RAM. I did a few sanity checks, including invalidating the build - seems fine.