### PR TITLE
Make main.dart.js load upon subdirectory refresh

### DIFF
--- a/angular_router/example/web/index.html
+++ b/angular_router/example/web/index.html
@@ -4,7 +4,7 @@
   <link rel="stylesheet" href="styles.css">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script defer src="main.dart.js"></script>
+  <script defer src="/main.dart.js"></script>
   <title>Router Sample</title>
 </head>
 <body>


### PR DESCRIPTION
Without a leading "/", main.dart.js won't load on site.com/sub/directories. (The server will look for site.com/sub/directories/main.dart.js, and upon not finding such a file, it will rewrite main.dart.js to *this* index.html file, causing browser console error "Unexpected token <"  whenever a subdirectory is refreshed.)