### PR TITLE
Start XVFB prior to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,3 +166,9 @@ cache:
     - examples/hello_world/.dart_tool
     - examples/hello_world_no_reflector/.dart_tool
     # END MANUAL EDITS.
+
+# Necessary for Chrome and Firefox to run
+before_install:
+ - export DISPLAY=:99.0
+ - sh -e /etc/init.d/xvfb start
+ - "t=0; until (xdpyinfo -display :99 &> /dev/null || test $t -gt 10); do sleep 1; let t=$t+1; done"


### PR DESCRIPTION
This was removed when we were running with Chrome Headless. Unfortunately Headless has some issues with the latest SDK https://github.com/dart-lang/test/issues/772 so we must run with full Chrome for the time being. This will allow us to run with the latest test package and latest SDK without issues.