### PR TITLE
Fix README 404

### DIFF
--- a/angular/README.md
+++ b/angular/README.md
@@ -38,7 +38,7 @@ a set of [community contributed tutorials][comm].
 [codelab1]: https://codelabs.developers.google.com/codelabs/your-first-angulardart-web-app/
 [tutorial]: https://webdev.dartlang.org/angular/tutorial
 [codelabs]: https://webdev.dartlang.org/codelabs
-[comm]: https://dart.academy/tag/angular2/
+[comm]: https://dart.academy/tag/angular/
 [webdev_components]: https://webdev.dartlang.org/components
 
 


### PR DESCRIPTION
dart.academy no longer recognizes angular2 as a tag

This fixes one of the broken links reported in https://github.com/dart-lang/site-webdev/issues/1345

@kwalrath