### PR TITLE
feat(DI): Add support for the 'Module' class.

### DIFF
--- a/_tests/test/di/injector_test.dart
+++ b/_tests/test/di/injector_test.dart
@@ -432,6 +432,28 @@ void main() {
         final InjectsXsrfToken service = injector.get(InjectsXsrfToken);
         expect(service.token, 'ABC123');
       });
+
+      test('should support a Module class instead of a List', () {
+        final injector = new Injector.slowReflective([
+          const Module(
+            include: const [
+              const Module(
+                provide: const [
+                  const ValueProvider(ExampleService, const ExampleService()),
+                ],
+              ),
+            ],
+            provide: const [
+              const ValueProvider(ExampleService2, const ExampleService2()),
+              const ExistingProvider(ExampleService, ExampleService2),
+            ],
+          ),
+        ]);
+        expect(
+          injector.get(ExampleService),
+          const isInstanceOf<ExampleService2>(),
+        );
+      });
     });
 
     group('.generate', () {
@@ -537,6 +559,13 @@ void main() {
         final InjectsXsrfToken service = injector.get(InjectsXsrfToken);
         expect(service.token, 'ABC123');
       });
+
+      test('should support Module', () {
+        expect(
+          exampleFromModule().get(ExampleService),
+          const isInstanceOf<ExampleService2>(),
+        );
+      });
     });
   });
 }
@@ -561,7 +590,9 @@ class ExampleService {
   const ExampleService();
 }
 
-class ExampleService2 implements ExampleService {}
+class ExampleService2 implements ExampleService {
+  const ExampleService2();
+}
 
 class ExampleService3 {}
 
@@ -636,6 +667,23 @@ Null willNeverBeCalled2(Object _, Object __) => null;
   InjectsXsrfToken,
 ])
 final InjectorFactory exampleGenerated = ng.exampleGenerated$Injector;
+
+@GenerateInjector.fromModules(const [
+  const Module(
+    include: const [
+      const Module(
+        provide: const [
+          const ValueProvider(ExampleService, const ExampleService()),
+        ],
+      ),
+    ],
+    provide: const [
+      const ValueProvider(ExampleService2, const ExampleService2()),
+      const ExistingProvider(ExampleService, ExampleService2),
+    ],
+  ),
+])
+final InjectorFactory exampleFromModule = ng.exampleFromModule$Injector;
 
 ExampleService createExampleService() => new ExampleService();
 List createListWith(String item) => [item];

--- a/angular/lib/src/di/injector/injector.dart
+++ b/angular/lib/src/di/injector/injector.dart
@@ -1,6 +1,8 @@
 import 'package:meta/meta.dart';
 
 import '../errors.dart' as errors;
+import '../module.dart';
+
 import 'empty.dart';
 import 'hierarchical.dart';
 import 'map.dart';
@@ -146,4 +148,10 @@ class GenerateInjector {
   final List<Object> _providersOrModules;
 
   const GenerateInjector(this._providersOrModules);
+
+  /// Generate an [Injector] from [Module]s instead of untyped lists.
+  @experimental
+  const factory GenerateInjector.fromModules(
+    List<Module> modules,
+  ) = GenerateInjector;
 }

--- a/angular/lib/src/di/injector/runtime.dart
+++ b/angular/lib/src/di/injector/runtime.dart
@@ -3,6 +3,7 @@ import 'package:angular/src/runtime.dart';
 import '../../core/di/decorators.dart';
 import '../../core/di/opaque_token.dart';
 import '../errors.dart' as errors;
+import '../module.dart';
 import '../providers.dart';
 import '../reflector.dart' as reflector;
 
@@ -251,6 +252,9 @@ _FlatProviders _flattenProviders(
       allProviders[item.token] = item;
     } else if (item is Type) {
       allProviders[item] = new Provider(item, useClass: item);
+    } else if (item is Module) {
+      final providers = internalModuleToList(item);
+      _flattenProviders(providers, allProviders, multiProviders);
     } else {
       assert(false, 'Unsupported: $item');
     }

--- a/angular/lib/src/di/module.dart
+++ b/angular/lib/src/di/module.dart
@@ -18,18 +18,18 @@ import 'providers.dart';
 /// ```dart
 /// // Before.
 /// const carModule = const [
-///   const Provider(Car, useClass: AmericanCar),
+///   const ClassProvider(Car, useClass: AmericanCar),
 /// ];
 ///
 /// const autoShopModule = const [
 ///   carModule,
-///   const Provider(Oil, useClass: GenericOil),
+///   const ClassProvider(Oil, useClass: GenericOil),
 /// ];
 ///
 /// // After.
 /// const carModule = const Module(
 ///   provide: const [
-///     const Provider(Car, useClass: AmericanCar),
+///     const ClassProvider(Car, useClass: AmericanCar),
 ///   ],
 /// );
 ///
@@ -38,7 +38,7 @@ import 'providers.dart';
 ///     carModule,
 ///   ],
 ///   provide: const [
-///     const Provider(Oil, useClass: GenericOil),
+///     const ClassProvider(Oil, useClass: GenericOil),
 ///   ],
 /// );
 /// ```
@@ -47,6 +47,7 @@ class Module {
   final List<Module> include;
   final List<Provider<Object>> provide;
 
+  @literal
   const factory Module({
     List<Module> include,
     List<Provider<Object>> provide,


### PR DESCRIPTION
This was deceivingly easy, mostly because (a) generated injectors already supported it, just wasn't documented, and (b) the runtime injector implementation is ~1 line. The bulk of the work, as usual, will be supporting in the view compiler - but I imagine it won't be too bad (again, can just "flatten" the module into a provider list).

Partial work towards https://github.com/dart-lang/angular/issues/543.