### PR TITLE
WIP: Use AstDirectiveNormalizer. Not all tests pass.

### DIFF
--- a/angular/lib/src/compiler/ast_directive_normalizer.dart
+++ b/angular/lib/src/compiler/ast_directive_normalizer.dart
@@ -122,7 +122,12 @@ class AstDirectiveNormalizer implements DirectiveNormalizer {
   ) {
     // Parse the template, and visit to find <style>/<link> and <ng-content>.
     final visitor = new _TemplateNormalizerVisitor();
-    final parsedNodes = ast.parse(template, sourceUrl: templateAbsUrl);
+    final parsedNodes = ast.parse(
+      template,
+      // TODO: Use the full-file path when possible.
+      // Otherwise, the analyzer crashes today seeing an 'asset:...' URL.
+      sourceUrl: Uri.parse(templateAbsUrl).replace(scheme: 'file').toFilePath(),
+    );
     parsedNodes.forEach((a) => a.accept(visitor));
 
     final allInlineStyles = templateMeta.styles + visitor.inlineStyles;

--- a/angular/lib/src/source_gen/common/ng_compiler.dart
+++ b/angular/lib/src/source_gen/common/ng_compiler.dart
@@ -1,9 +1,8 @@
 import 'package:build/build.dart' hide AssetReader;
+import 'package:angular/src/compiler/ast_directive_normalizer.dart';
 import 'package:angular/src/compiler/ast_template_parser.dart';
-import 'package:angular/src/compiler/directive_normalizer.dart';
 import 'package:angular/src/compiler/expression_parser/lexer.dart' as ng;
 import 'package:angular/src/compiler/expression_parser/parser.dart' as ng;
-import 'package:angular/src/compiler/html_parser.dart';
 import 'package:angular/src/compiler/offline_compiler.dart';
 import 'package:angular/src/compiler/output/dart_emitter.dart';
 import 'package:angular/src/compiler/schema/dom_element_schema_registry.dart';
@@ -15,12 +14,11 @@ import 'package:angular_compiler/cli.dart';
 OfflineCompiler createTemplateCompiler(
     BuildStep buildStep, CompilerFlags flags) {
   var parser = new ng.Parser(new ng.Lexer());
-  var htmlParser = new HtmlParser();
   var schemaRegistry = new DomElementSchemaRegistry();
   var templateParser = new AstTemplateParser(schemaRegistry, parser, flags);
   final reader = new NgAssetReader.fromBuildStep(buildStep);
   return new OfflineCompiler(
-      new DirectiveNormalizer(htmlParser, reader),
+      new AstDirectiveNormalizer(reader),
       templateParser,
       new StyleCompiler(flags),
       new ViewCompiler(flags, parser, schemaRegistry),

--- a/angular_ast/lib/src/exception_handler/angular_parser_exception.dart
+++ b/angular_ast/lib/src/exception_handler/angular_parser_exception.dart
@@ -15,11 +15,15 @@ class AngularParserException extends Error {
   /// Offset of where the exception was detected.
   final int offset;
 
+  /// Details of the exception
+  final String message;
+
   AngularParserException(
     this.errorCode,
     this.offset,
-    this.length,
-  );
+    this.length, [
+    this.message = '',
+  ]);
 
   @override
   bool operator ==(Object o) {
@@ -35,5 +39,5 @@ class AngularParserException extends Error {
   int get hashCode => hash3(errorCode, length, offset);
 
   @override
-  String toString() => 'AngularParserException{$errorCode}';
+  String toString() => 'AngularParserException{$errorCode}: $message';
 }

--- a/angular_ast/lib/src/visitors/expression_parser_visitor.dart
+++ b/angular_ast/lib/src/visitors/expression_parser_visitor.dart
@@ -144,9 +144,17 @@ class ExpressionParserVisitor implements TemplateAstVisitor<dynamic, Null> {
         e.errorCode,
         e.offset,
         e.length,
+        'Failed parsing [$expression] at offer $offset: ${e.message}',
       ));
     } on AngularParserException catch (e) {
-      exceptionHandler.handle(e);
+      exceptionHandler.handle(
+        new AngularParserException(
+          e.errorCode,
+          e.offset,
+          e.length,
+          'Failed parsing [$expression] at offset $offset',
+        ),
+      );
     }
     return null;
   }

--- a/angular_compiler/lib/src/cli/logging.dart
+++ b/angular_compiler/lib/src/cli/logging.dart
@@ -45,7 +45,7 @@ Future<T> runBuildZoned<T>(
       } else {
         build.log.severe(
           'Unhandled exception in the AngularDart compiler!\n\n'
-              'Please report a bug: ${messages.urlFileBugs}',
+          'Please report a bug: ${messages.urlFileBugs}\n\n$e\n$s',
           e,
           s,
         );


### PR DESCRIPTION
Here is the latest result (locally) of running the tests:
https://gist.github.com/matanlurey/8abcf3d8f2a3dc01ef6a2f37e56066d3

It looks like the expression parsing, specifically, is not the same.