### PR TITLE
feat(Compiler): More work towards AstDirectiveNormalizer.

### DIFF
--- a/angular/lib/src/compiler/ast_directive_normalizer.dart
+++ b/angular/lib/src/compiler/ast_directive_normalizer.dart
@@ -122,7 +122,12 @@ class AstDirectiveNormalizer implements DirectiveNormalizer {
   ) {
     // Parse the template, and visit to find <style>/<link> and <ng-content>.
     final visitor = new _TemplateNormalizerVisitor();
-    final parsedNodes = ast.parse(template, sourceUrl: templateAbsUrl);
+    final parsedNodes = ast.parse(
+      template,
+      // TODO: Use the full-file path when possible.
+      // Otherwise, the analyzer crashes today seeing an 'asset:...' URL.
+      sourceUrl: Uri.parse(templateAbsUrl).replace(scheme: 'file').toFilePath(),
+    );
     parsedNodes.forEach((a) => a.accept(visitor));
 
     final allInlineStyles = templateMeta.styles + visitor.inlineStyles;
@@ -144,10 +149,8 @@ class AstDirectiveNormalizer implements DirectiveNormalizer {
     // Try to resolve <style> import statements.
     for (final inlineStyle in allInlineStyles) {
       final import = extractStyleUrls(templateAbsUrl, inlineStyle);
-      for (final url in import.styleUrls) {
-        allExternalStyles.add(url);
-        allResolvedStyles.add(import.style);
-      }
+      allExternalStyles.addAll(import.styleUrls);
+      allResolvedStyles.add(import.style);
     }
 
     // Optimization: Turn off encapsulation when there are no styles to apply.

--- a/angular_compiler/lib/src/cli/flags.dart
+++ b/angular_compiler/lib/src/cli/flags.dart
@@ -80,11 +80,18 @@ class CompilerFlags {
   @experimental
   final bool useNewPreserveWhitespace;
 
+  /// Whether to use a new implementation for template normalization.
+  ///
+  /// This processes inline and external stylesheets, external templates.
+  @experimental
+  final bool useNewTemplateNormalizer;
+
   const CompilerFlags({
     this.genDebugInfo: false,
     this.ignoreNgPlaceholderForGoldens: false,
     this.profileFor: Profile.none,
     this.useFastBoot: true,
+    this.useNewTemplateNormalizer: false,
     this.useLegacyStyleEncapsulation: false,
     this.useNewPreserveWhitespace: false,
   });


### PR DESCRIPTION
Added an (internal) flag called `useNewTemplateNormalizer`, set to `false`.

When `true`, all the tests pass, except for `binding_test.dart`:
https://github.com/dart-lang/angular/blob/03dae0d6c5a952b55ae5cb1bd59678febd6dd57a/_tests/test/core/change_detection/binding_test.dart#L187-L199

... it crashes parsing that template expression.

Other fixes:
* Use a valid URL (otherwise crashes the analyzer) for the normalizer.
* Fixed a bug where inline stylesheets weren't processed correctly.