### PR TITLE
Remove use of pkg:http, preload first news page

### DIFF
--- a/examples/hacker_news_pwa/build.release.yaml
+++ b/examples/hacker_news_pwa/build.release.yaml
@@ -11,3 +11,4 @@ targets:
           - --minify
           - --trust-type-annotations
           - --trust-primitives
+          - --dump-info

--- a/examples/hacker_news_pwa/lib/hacker_news_service.dart
+++ b/examples/hacker_news_pwa/lib/hacker_news_service.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:html';
 
 import 'package:angular/angular.dart';
-import 'package:http/http.dart';
 
 /// Represents the base URL for HTTP requests using [HackerNewsService].
 const baseUrl = const OpaqueToken<String>('baseUrl');
@@ -10,19 +10,18 @@ const defaultBaseUrl = 'https://node-hnapi.herokuapp.com';
 
 class HackerNewsService {
   final String _baseUrl;
-  final BaseClient _client;
 
-  HackerNewsService(@baseUrl this._baseUrl, this._client);
+  HackerNewsService(@baseUrl this._baseUrl);
 
   Future<List<Map>> getFeed(String name, int page) async {
     final url = '$_baseUrl/$name?page=$page';
-    final response = await _client.get(url);
-    return JSON.decode(response.body);
+    final response = await HttpRequest.getString(url);
+    return JSON.decode(response);
   }
 
   Future<Map> getItem(String id) async {
     final url = '$_baseUrl/item/$id';
-    final response = await _client.get(url);
-    return JSON.decode(response.body);
+    final response = await HttpRequest.getString(url);
+    return JSON.decode(response);
   }
 }

--- a/examples/hacker_news_pwa/pubspec.yaml
+++ b/examples/hacker_news_pwa/pubspec.yaml
@@ -5,7 +5,6 @@ environment:
 dependencies:
   angular: ^5.0.0-alpha
   angular_router: ^2.0.0-alpha
-  http: ^0.11.3+13
   pwa: ^0.1.7
 
 dev_dependencies:

--- a/examples/hacker_news_pwa/web/index.html
+++ b/examples/hacker_news_pwa/web/index.html
@@ -9,6 +9,7 @@
   <title>Hacker News - AngularDart PWA</title>
   <script defer src="main.dart.js"></script>
   <link rel="manifest" href="manifest.json">
+  <link rel="preload" href="https://node-hnapi.herokuapp.com/news?page=1" as=fetch crossorigin >
   <style>
     * {
       box-sizing: border-box;

--- a/examples/hacker_news_pwa/web/main.dart
+++ b/examples/hacker_news_pwa/web/main.dart
@@ -1,8 +1,6 @@
 import 'package:angular/angular.dart';
 import 'package:angular/experimental.dart';
 import 'package:angular_router/angular_router.dart';
-import 'package:http/http.dart';
-import 'package:http/browser_client.dart';
 import 'package:pwa/client.dart' as pwa;
 
 // We are ignoring files that will be generated at compile-time.
@@ -17,15 +15,12 @@ import 'main.template.dart' as ng;
 @GenerateInjector(const [
   // HTTP and Services.
   const ClassProvider(HackerNewsService),
-  const FactoryProvider(BaseClient, createBrowserClient),
   const ValueProvider.forToken(baseUrl, defaultBaseUrl),
 
   // SPA Router.
   routerProviders,
 ])
 final InjectorFactory hackerNewsApp = ng.hackerNewsApp$Injector;
-
-BrowserClient createBrowserClient() => new BrowserClient();
 
 void main() {
   // Install service worker.


### PR DESCRIPTION
before: 405,705, after: 336,164
69K, 17% smaller - uncompressed

2s faster to interactive: https://www.webpagetest.org/video/compare.php?tests=180318_QQ_72ed89af4587e6a803d3d39338640d7c,180317_ZY_d2c37ca1631c7a550d1e73d3f71ff518