### PR TITLE
[WIP] minor changes for webdev doc integration

### DIFF
--- a/doc/bazel.md
+++ b/doc/bazel.md
@@ -1,4 +1,6 @@
-# Building with Bazel
+---
+title: Building with Bazel
+---
 
 ## Collecting metrics
 
@@ -26,9 +28,9 @@ see logged metrics for any dependencies of the target you're compiling. To
 prevent filtering and see metrics for the entire build, use
 [`--auto_output_filter=none`][auto_output_filter].
 
-```
+```terminal
 $ bazel clean
-$ bazel build --auto_output_filter=none //<path>:<target>
+$ bazel build --auto_output_filter=none # <path>:<target>
 ```
 
 (`--auto_output_filter` is only currently supported on the internal Bazel)

--- a/doc/building_angular.md
+++ b/doc/building_angular.md
@@ -1,4 +1,7 @@
-# Building Angular
+---
+layout: angular
+title: Building Angular
+---
 
 AngularDart uses `package:build` as a build system for compiling Angular
 components.
@@ -6,14 +9,14 @@ components.
 1.  Edit your package's **pubspec.yaml** file, adding dev dependencies on
     **build_runner** and **build_web_compilers**:
 
+    <?code-excerpt "hello_world/pubspec.yaml (env-dev-dep)"?>
     ```yaml
-    ...
     environment:
-      sdk: '>=2.0.0-dev <2.0.0'
-    ...
+      sdk: ">=2.0.0-dev.28.0 <2.0.0"
+
     dev_dependencies:
-      build_runner: ^0.7.0
-      build_web_compilers: ^0.2.0
+      build_runner: ^0.8.0
+      build_web_compilers: ^0.3.4+1
     ```
 
 2.  Get package dependencies:

--- a/examples/hello_world/pubspec.yaml
+++ b/examples/hello_world/pubspec.yaml
@@ -1,15 +1,22 @@
+# #docplaster
 name: examples.hello_world
 
+# #docregion env-dev-dep
 environment:
   sdk: ">=2.0.0-dev.28.0 <2.0.0"
 
+# #enddocregion env-dev-dep
 dependencies:
   angular: ^5.0.0-alpha
 
+# #docregion env-dev-dep
 dev_dependencies:
   build_runner: ^0.8.0
+  # #enddocregion env-dev-dep
   build_test: ^0.10.1+1
+  # #docregion env-dev-dep
   build_web_compilers: ^0.3.4+1
+# #enddocregion env-dev-dep
 
 # DO NOT REMOVE. We don't publish this package, it is just for testing.
 dependency_overrides:


### PR DESCRIPTION
This is an example of the minor changes that would be required to the doc pages to allow them to be integrated into site-webdev. Pending minor changes to site-webdev, this could be deployed as follows:

- https://angulardart-org-dev2.firebaseapp.com/angular/notes/building_angular
- https://angulardart-org-dev2.firebaseapp.com/angular/notes/bazel

I'd propose that we host these pages as **Engineering Notes**.

cc @kwalrath 