### PR TITLE
Fixed an issue in angular_compiler

### DIFF
--- a/angular_compiler/lib/src/cli/flags.dart
+++ b/angular_compiler/lib/src/cli/flags.dart
@@ -86,6 +86,8 @@ class CompilerFlags {
   @experimental
   final bool useNewTemplateNormalizer;
 
+  final bool useAstPkg;
+
   const CompilerFlags({
     this.genDebugInfo: false,
     this.ignoreNgPlaceholderForGoldens: false,
@@ -94,6 +96,7 @@ class CompilerFlags {
     this.useNewTemplateNormalizer: false,
     this.useLegacyStyleEncapsulation: false,
     this.useNewPreserveWhitespace: false,
+    this.useAstPkg: true,
   });
 
   /// Creates flags by parsing command-line arguments.


### PR DESCRIPTION
This pull request will fix:

https://github.com/dart-lang/angular/issues/1148
And 
https://github.com/dart-lang/build/issues/1206

I don't know what happens after adding `final bool useAstPkg;` to class `CompilerFlags`, but somehow it fixed above issue.