### PR TITLE
fix(Compiler): ParserError implements BuildError.

### DIFF
--- a/angular/lib/src/compiler/parse_util.dart
+++ b/angular/lib/src/compiler/parse_util.dart
@@ -1,14 +1,18 @@
+import 'package:angular_compiler/cli.dart';
 import 'package:source_span/source_span.dart';
 
 enum ParseErrorLevel { WARNING, FATAL }
 
-abstract class ParseError {
-  final SourceSpan span;
-  final String msg;
-  final ParseErrorLevel level;
+abstract class ParseError implements BuildError {
+  final SourceSpan _span;
+  final String _msg;
+  final ParseErrorLevel _level;
 
-  ParseError(this.span, this.msg, [this.level = ParseErrorLevel.FATAL]);
+  ParseError(this._span, this._msg, [this._level = ParseErrorLevel.FATAL]);
 
   @override
-  String toString() => span.message('$level: $msg');
+  String get message => _span.message('$_level: $_msg');
+
+  @override
+  String toString() => message;
 }


### PR DESCRIPTION
... we handle `BuildError` special, and suppress the `StackTrace`.

These types of errors that have good context we don't want to report as a compiler bug.