### PR TITLE
chore(*): Upgrade quiver dependency for Dart2.

### DIFF
--- a/_tests/pubspec.yaml
+++ b/_tests/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # Actual valid dependencies required.
   collection: ^1.14.5
   meta: ^1.1.2
-  quiver: ^0.28.0
+  quiver: ^0.29.0+1
   test: ^0.12.32
 
 dev_dependencies:

--- a/angular/pubspec.yaml
+++ b/angular/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   code_builder: '^3.0.1'
   csslib: ^0.14.1
   path: ^1.5.1
-  quiver: '>=0.22.0 <0.29.0'
+  quiver: ^0.29.0+1
   source_gen: ^0.8.0
   source_span: ^1.4.0
   tuple: ^1.0.1

--- a/angular_ast/pubspec.yaml
+++ b/angular_ast/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   collection: ^1.14.5
   string_scanner: ^1.0.1
   meta: ^1.1.2
-  quiver: '>=0.22.0 <0.29.0'
+  quiver: ^0.29.0+1
   source_span: ^1.4.0
 
 dev_dependencies:


### PR DESCRIPTION
... otherwise it breaks due to `Maps` being removed from the SDK.