### PR TITLE
feat(Compiler): Refine and test `@HostBinding` usage.

### DIFF
--- a/_tests/test/core/functional_directive_test.dart
+++ b/_tests/test/core/functional_directive_test.dart
@@ -1,10 +1,9 @@
 @TestOn('browser')
-
 import 'dart:html';
 
-import 'package:test/test.dart';
 import 'package:angular/angular.dart';
 import 'package:angular_test/angular_test.dart';
+import 'package:test/test.dart';
 
 import 'functional_directive_test.template.dart' as ng_generated;
 

--- a/_tests/test/core/host_annotation_test.dart
+++ b/_tests/test/core/host_annotation_test.dart
@@ -1,0 +1,64 @@
+@TestOn('browser')
+import 'dart:async';
+import 'dart:html';
+
+import 'package:angular/angular.dart';
+import 'package:angular_test/angular_test.dart';
+import 'package:test/test.dart';
+
+import 'host_annotation_test.template.dart' as ng;
+
+void main() {
+  tearDown(disposeAnyRunningTest);
+
+  /// Returns the root [Element] created by initializing [component].
+  Future<Element> rootElementOf<T>(ComponentFactory<T> component) {
+    final testBed = NgTestBed.forComponent<T>(component);
+    return testBed.create().then((fixture) => fixture.rootElement);
+  }
+
+  group('@HostBinding', () {
+    test('should assign "title" based on a static', () async {
+      final element = await rootElementOf(
+        ng.HostBindingStaticTitleNgFactory,
+      );
+      expect(element.title, 'Hello World');
+    });
+
+    test('should *not* assign "title" based on an inherited static', () async {
+      // The language does not inherit static members, so AngularDart inheriting
+      // them would (a) seem out of place and (b) make the compilation process
+      // for these bindings considerably more complex.
+      //
+      // This test verifies that nothing is inherited. A user can always use an
+      // instance getter or field and everything would work exactly as intended.
+      //
+      // https://github.com/dart-lang/angular/issues/1272
+      final element = await rootElementOf(
+        ng.HostBindingStaticTitleNotInheritedNgFactory,
+      );
+      expect(element.title, isEmpty);
+    });
+
+    // TODO: Add additional tests for @HostBinding.
+  });
+
+  group('@HostListener', () {
+    // TODO: Add tests for @HostListener.
+  });
+}
+
+@Component(
+  selector: 'host-binding-static',
+  template: '',
+)
+class HostBindingStaticTitle {
+  @HostBinding('title')
+  static const hostTitle = 'Hello World';
+}
+
+@Component(
+  selector: 'host-binding-static-inherited',
+  template: '',
+)
+class HostBindingStaticTitleNotInherited extends HostBindingStaticTitle {}

--- a/angular/lib/src/core/metadata.dart
+++ b/angular/lib/src/core/metadata.dart
@@ -772,65 +772,41 @@ class Output {
   const Output([this.bindingPropertyName]);
 }
 
-/// Declares a host property binding.
+/// Declares a host property on the host component or element.
 ///
-/// Host property bindings are automatically checked during change detection. If
-/// a binding changes, the host element of the directive is updated.
+/// This annotation is valid on:
+/// * Public class members
+/// * The class members may either be fields or getters
+/// * The class members may either be static or instance
 ///
-/// The [HostBinding] annotation takes an optional parameter that
-/// specifies the property name of the host element that will be updated. When
-/// not provided, the property name is used.
+/// This annotation is _inherited_ if declared on an instance member.
 ///
-/// ### Example
-///
-/// With class bindings:
-///
-/// The following example creates a directive that sets the `valid` and
-/// `invalid` classes on the DOM element that has ngModel directive on it.
-///
-/// ```dart
-/// @Directive(selector: '[ngModel]')
-/// class NgModelStatus {
-///   NgModel control;
-///
-///   NgModelStatus(this.control);
-///
-///   @HostBinding('class.valid')
-///   bool get valid => return control.valid;
-///
-///   @HostBinding('class.invalid')
-///   bool get invalid => control.invalid;
+/// If [hostPropertyName] is not specified, it defaults to the property or
+/// getter name. For example in the following, `'title'` is implicitly used:
+/// ```
+/// @Directive(...)
+/// class ImplicitName {
+///   // Same as @HostBinding('title')
+///   @HostBinding()
+///   final title = 'Hello World';
 /// }
-///
-/// @Component(
-///   selector: 'app',
-///   template: '<input [(ngModel)]="prop">',
-///   directives: const [formDirectives, NgModelStatus])
-/// class App {
-///   var prop;
-///  }
 /// ```
 ///
-/// With attribute bindings:
+/// These bindings are nearly identical to using the template syntax to set
+/// properties or attributes, and are automatically updated if the referenced
+/// class member, instance or static, changes:
+/// ```
+/// @Directive(...)
+/// class HostBindingExample {
+///   // Similar to <example [value]="hostValue"> in a template.
+///   @HostBinding('value')
+///   String hostValue;
 ///
-/// The following example creates a checkbox component which reflects its state
-/// as attributes on the host element.  When the checkbox is disabled, it sets
-/// the tabindex to -1 to move it out of tab order. When the checkbox is checked
-/// the host element will add a "checked" boolean attribute.
-///
-/// ```dart
-/// @Component(selector: 'ng-checkbox', template: '...')
-/// class NgCheckboxComponent {
-///    bool disabled;
-///    bool isChecked;
-///
-///   @HostBinding('attr.tabindex')
-///   String get tabIndex => disabled ? '-1' : '1';
-///
-///   @HostBinding('attr.checked')
-///   String get checked => isChecked ? '' : null;
+///   // Similar to <example [attr.debug-id]="debugId"> in a template.
+///   @HostBinding('attr.debug-id')
+///   String debugId;
 /// }
-///```
+/// ```
 class HostBinding {
   final String hostPropertyName;
   const HostBinding([this.hostPropertyName]);

--- a/angular/lib/src/source_gen/template_compiler/find_components.dart
+++ b/angular/lib/src/source_gen/template_compiler/find_components.dart
@@ -456,6 +456,11 @@ class ComponentVisitor
     var bindTo = element.name;
     if (element is PropertyAccessorElement && element.isStatic ||
         element is FieldElement && element.isStatic) {
+      if (element.enclosingElement != _directiveClassElement) {
+        // We do not want to inherit static members.
+        // https://github.com/dart-lang/angular/issues/1272
+        return;
+      }
       bindTo = '${_directiveClassElement.name}.$bindTo';
     }
     _hostProperties[property] = bindTo;


### PR DESCRIPTION
Partial work towards https://github.com/dart-lang/angular/issues/1272.

In particular, it explicitly disables inheriting static `@HostBinding()` declarations, which before would generate invalid code (that later DDC or Dart2JS would fail to compile). This is now tested as well.