### PR TITLE
fix(Compiler): fixes order of `@import` styles

### DIFF
--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -42,6 +42,10 @@
     class FancyButton extends Base {}
     ```
 
+*   Styles from an `@import` statement are now included _before_ the styles
+    declared within the file, instead of _after_. This allows a style declared
+    within a file to override an imported one of equivalent specificity.
+
 ## 5.0.0-alpha+11
 
 ### Breaking changes

--- a/angular/lib/src/compiler/style_compiler.dart
+++ b/angular/lib/src/compiler/style_compiler.dart
@@ -56,18 +56,27 @@ class StyleCompiler {
         styleWithImports.styleUrls, isShimmed);
   }
 
-  StylesCompileResult _compileStyles(String stylesVar, List<String> plainStyles,
-      List<String> absUrls, bool shim) {
-    List<o.Expression> styleExpressions = <o.Expression>[];
-    int styleCount = plainStyles.length;
-    for (int s = 0; s < styleCount; s++) {
-      styleExpressions.add(o.literal(this._shimIfNeeded(plainStyles[s], shim)));
-    }
-    for (var i = 0; i < absUrls.length; i++) {
-      var identifier = new CompileIdentifierMetadata(
-          name: getStylesVarName(),
-          moduleUrl: stylesModuleUrl(absUrls[i], shim));
+  StylesCompileResult _compileStyles(
+    String stylesVar,
+    List<String> styles,
+    List<String> styleUrls,
+    bool shim,
+  ) {
+    final styleExpressions = <o.Expression>[];
+
+    /// Add URLs from @import statements first.
+    for (final url in styleUrls) {
+      final identifier = new CompileIdentifierMetadata(
+        name: getStylesVarName(),
+        moduleUrl: stylesModuleUrl(url, shim),
+      );
       styleExpressions.add(new o.ExternalExpr(identifier));
+    }
+
+    /// Add contents of style sheet after @import statements. This allows an
+    /// imported style to be overriden after its @import statement.
+    for (final style in styles) {
+      styleExpressions.add(o.literal(_shimIfNeeded(style, shim)));
     }
 
     // Styles variable contains plain strings and arrays of other styles arrays


### PR DESCRIPTION
Styles from an `@import` statement were included _after_ the main contents of
the file, when they should have been included _before_.