### PR TITLE
fix(Compiler): fixes @import for package URLs

### DIFF
--- a/_tests/test/compiler/ast_directive_normalizer_test.dart
+++ b/_tests/test/compiler/ast_directive_normalizer_test.dart
@@ -143,9 +143,7 @@ void main() {
         'package:a/3.css',
         'package:a/1.css',
         'package:a/2.css',
-
-        // @import URLs are not resolved at build-time.
-        'packages/a/4.css',
+        'package:a/4.css',
       ]),
     );
   });

--- a/_tests/test/compiler/style_url_resolver_test.dart
+++ b/_tests/test/compiler/style_url_resolver_test.dart
@@ -66,7 +66,7 @@ void main() {
       var css = '''@import url(\'package:a/b/some.css\');''';
       var styleWithImports = extractStyleUrls("http://ng.io", css);
       expect(styleWithImports.style.trim(), '''''');
-      expect(styleWithImports.styleUrls, ["packages/a/b/some.css"]);
+      expect(styleWithImports.styleUrls, ["package:a/b/some.css"]);
     });
   });
   group("isStyleUrlResolvable", () {

--- a/angular/lib/src/compiler/style_url_resolver.dart
+++ b/angular/lib/src/compiler/style_url_resolver.dart
@@ -1,23 +1,22 @@
-// Some of the code comes from WebComponents.JS
-// https://github.com/webcomponents/webcomponentsjs/blob/master/src/HTMLImports/path.js
-
 class StyleWithImports {
-  String style;
-  List<String> styleUrls;
+  final String style;
+  final List<String> styleUrls;
   StyleWithImports(this.style, this.styleUrls);
 }
 
+/// Whether [url] resides within the current package or a dependency.
 bool isStyleUrlResolvable(String url) {
-  if (url == null || url.isEmpty || url[0] == "/") return false;
+  if (url == null || url.isEmpty || url[0] == '/') return false;
   var schemeMatch = _urlWithSchemaRe.firstMatch(url);
   return schemeMatch == null ||
-      schemeMatch[1] == "package" ||
-      schemeMatch[1] == "asset";
+      schemeMatch[1] == 'package' ||
+      schemeMatch[1] == 'asset';
 }
 
-/// Rewrites stylesheets by resolving and removing the @import urls that
+/// Rewrites style sheets by resolving and removing the @import urls that
 /// are either relative or don't have a `package:` scheme
 StyleWithImports extractStyleUrls(String baseUrl, String cssText) {
+  Uri baseUri;
   var foundUrls = <String>[];
   var modifiedCssText = cssText.replaceAllMapped(_cssImportRe, (m) {
     var url = m[1] ?? m[2];
@@ -25,67 +24,11 @@ StyleWithImports extractStyleUrls(String baseUrl, String cssText) {
       // Do not attempt to resolve non-package absolute URLs with URI scheme
       return m[0];
     }
-    foundUrls.add(resolveUrl(baseUrl, url));
-    return "";
+    baseUri ??= Uri.parse(baseUrl);
+    foundUrls.add(baseUri.resolve(url).toString());
+    return '';
   });
   return new StyleWithImports(modifiedCssText, foundUrls);
-}
-
-/// Resolves the `url` given the `baseUrl`:
-/// - when the `url` is null, the `baseUrl` is returned,
-/// - if `url` is relative ('path/to/here', './path/to/here'), the resolved
-///   url is a combination of `baseUrl` and `url`,
-/// - if `url` is absolute (it has a scheme: 'http://', 'https://' or start
-///   with '/'), the `url` is returned as is (ignoring the `baseUrl`)
-///
-/// @param {string} baseUrl
-/// @param {string} url
-/// @returns {string} the resolved URL
-String resolveUrl(String baseUrl, String url) {
-  Uri uri = Uri.parse(url);
-  if (baseUrl != null && baseUrl.length > 0) {
-    Uri baseUri = Uri.parse(baseUrl);
-    uri = baseUri.resolveUri(uri);
-  }
-  var prefix = 'packages';
-  if (prefix != null && uri.scheme == 'package') {
-    if (prefix == _ASSET_SCHEME) {
-      var pathSegments = uri.pathSegments.toList()..insert(1, 'lib');
-      return new Uri(scheme: 'asset', pathSegments: pathSegments).toString();
-    } else {
-      prefix = _removeTrailingSlash(prefix);
-      var path = _removeLeadingChars(uri.path);
-      return '$prefix/$path';
-    }
-  } else {
-    return uri.toString();
-  }
-}
-
-const _ASSET_SCHEME = 'asset:';
-
-String _removeLeadingChars(String s) {
-  if (s?.isNotEmpty == true) {
-    var pos = 0;
-    for (var i = 0; i < s.length; i++) {
-      if (s[i] != '/') break;
-      pos++;
-    }
-    s = s.substring(pos);
-  }
-  return s;
-}
-
-String _removeTrailingSlash(String s) {
-  if (s?.isNotEmpty == true) {
-    var pos = s.length;
-    for (var i = s.length - 1; i >= 0; i--) {
-      if (s[i] != '/') break;
-      pos--;
-    }
-    s = s.substring(0, pos);
-  }
-  return s;
 }
 
 final _cssImportRe = new RegExp(r'@import\s+(?:url\()?\s*(?:(?:[' +
@@ -93,7 +36,4 @@ final _cssImportRe = new RegExp(r'@import\s+(?:url\()?\s*(?:(?:[' +
     r'"]([^' +
     "'" +
     r'"]*))|([^;\)\s]*))[^;]*;?');
-// TODO: can't use /^[^:/?#.]+:/g due to clang-format bug:
-
-//       https://github.com/angular/angular/issues/4596
-final _urlWithSchemaRe = new RegExp(r'^([a-zA-Z\-\+\.]+):');
+final _urlWithSchemaRe = new RegExp('^([^:/?#]+):');


### PR DESCRIPTION
The compiler was resolving URLs with the `package` scheme to the now
non-existent `packages/` directory. The `package` scheme is now preserved which
the build ecosystem understands.

Fixes https://github.com/dart-lang/angular/issues/1230.