### PR TITLE
Fixes Angular compiler warning and test expectation

### DIFF
--- a/_tests/test/common/directives/for_test.dart
+++ b/_tests/test/common/directives/for_test.dart
@@ -138,17 +138,11 @@ void main() {
 
     test("should throw on non-iterable ref and suggest using an array",
         () async {
-      var testBed = new NgTestBed<NgForOptionsTest>();
-      NgTestFixture<NgForOptionsTest> testFixture = await testBed.create();
-      bool didThrowException = false;
-      await testFixture.update((NgForOptionsTest component) {
-        component.items = "this is not iterable";
-      }).catchError((e) {
-        expect(e.toString(),
-            contains("Type 'String' is not a subtype of type 'Iterable'"));
-        didThrowException = true;
-      });
-      expect(didThrowException, true);
+      final testBed = new NgTestBed<NgForOptionsTest>();
+      final testFixture = await testBed.create();
+      expect(testFixture.update((component) {
+        component.items = 'this is not iterable';
+      }), throwsA(const isInstanceOf<TypeError>()));
     });
 
     test("should work with duplicates", () async {

--- a/_tests/test/core/change_detection/detect_host_changes_test.dart
+++ b/_tests/test/core/change_detection/detect_host_changes_test.dart
@@ -49,7 +49,7 @@ class ChildComponent extends SomeDirective {}
   selector: '[someDirective]',
 )
 class SomeDirective {
-  @HostBinding('role')
+  @HostBinding('attr.role')
   static const hostRole = 'button';
 
   @HostBinding('attr.data-xyz')


### PR DESCRIPTION
'role' isn't a native HTML property, but rather an attribute.

Dart 2.0.0-dev.51.0 type error messages have a more explicit representation of
dynamic type arguments. Rather than expecting the exact contents of the message,
we'll instead just check that a type argument is thrown.