### PR TITLE
feat(i18n): generates internationalized text for `@i18n`-annotated nodes

### DIFF
--- a/_goldens/test/_files/i18n/message.dart
+++ b/_goldens/test/_files/i18n/message.dart
@@ -1,0 +1,7 @@
+import 'package:angular/angular.dart';
+
+@Component(
+  selector: 'message',
+  template: '<p @i18n="description">message</p>',
+)
+class MessageComponent {}

--- a/_goldens/test/_files/i18n/message.template_debug.golden
+++ b/_goldens/test/_files/i18n/message.template_debug.golden
@@ -1,0 +1,99 @@
+// **************************************************************************
+// Generator: Instance of 'Compiler'
+// **************************************************************************
+
+// ignore_for_file: cancel_subscriptions,constant_identifier_names,duplicate_import,non_constant_identifier_names,library_prefixes,UNUSED_IMPORT,UNUSED_SHOWN_NAME
+import 'message.dart';
+export 'message.dart';
+import 'package:angular/angular.dart';
+import 'package:angular/src/di/reflector.dart' as _ngRef;
+import 'package:angular/angular.template.dart' as _ref0;
+import 'package:angular/src/debug/debug_context.dart';
+import 'package:angular/src/debug/debug_app_view.dart';
+import 'message.dart' as import2;
+import 'dart:html' as import3;
+import 'package:intl/intl.dart' as import4;
+import 'package:angular/src/core/render/api.dart';
+import 'package:angular/src/core/linker/app_view.dart';
+import 'package:angular/src/core/linker/view_type.dart' as import7;
+import 'package:angular/src/core/change_detection/change_detection.dart';
+import 'package:angular/src/core/linker/app_view_utils.dart' as import9;
+import 'package:angular/angular.dart';
+
+const List<dynamic> styles$MessageComponent = const [];
+List<StaticNodeDebugInfo> nodeDebugInfos_MessageComponent0 = [null, null];
+
+class ViewMessageComponent0 extends DebugAppView<import2.MessageComponent> {
+  import3.Element _el_0;
+  static final String _message_0 = import4.Intl.message('message', desc: 'description');
+  static RenderComponentType _renderType;
+  ViewMessageComponent0(AppView<dynamic> parentView, int parentIndex) : super(import7.ViewType.component, {}, parentView, parentIndex, ChangeDetectionStrategy.CheckAlways, nodeDebugInfos_MessageComponent0) {
+    rootEl = import3.document.createElement('message');
+    _renderType ??= import9.appViewUtils.createRenderType('asset:_goldens/test/_files/i18n/message.dart class MessageComponent - inline template', ViewEncapsulation.None, styles$MessageComponent);
+    setupComponentType(_renderType);
+  }
+  @override
+  ComponentRef<import2.MessageComponent> build() {
+    final _rootEl = rootEl;
+    final import3.HtmlElement parentRenderNode = initViewRoot(_rootEl);
+    var doc = import3.document;
+    _el_0 = createAndAppendDbg(this, doc, 'p', parentRenderNode, 0, 0, 0);
+    import3.Text _text_1 = new import3.Text(_message_0);
+    _el_0.append(_text_1);
+    dbgElm(this, _text_1, 1, 0, 23);
+    init(const [], null, [_el_0, _text_1]);
+    return null;
+  }
+}
+
+AppView<import2.MessageComponent> viewFactory_MessageComponent0(AppView<dynamic> parentView, int parentIndex) {
+  return new ViewMessageComponent0(parentView, parentIndex);
+}
+
+const List<dynamic> styles$MessageComponentHost = const [];
+List<StaticNodeDebugInfo> nodeDebugInfos_MessageComponentHost0 = [
+  new StaticNodeDebugInfo([import2.MessageComponent], import2.MessageComponent, <String, dynamic>{})
+];
+
+class _ViewMessageComponentHost0 extends DebugAppView<dynamic> {
+  ViewMessageComponent0 _compView_0;
+  import2.MessageComponent _MessageComponent_0_5;
+  _ViewMessageComponentHost0(AppView<dynamic> parentView, int parentIndex) : super(import7.ViewType.host, {}, parentView, parentIndex, ChangeDetectionStrategy.CheckAlways, nodeDebugInfos_MessageComponentHost0);
+  @override
+  ComponentRef build() {
+    _compView_0 = new ViewMessageComponent0(this, 0);
+    rootEl = _compView_0.rootEl;
+    dbgIdx(rootEl, 0);
+    _MessageComponent_0_5 = new import2.MessageComponent();
+    _compView_0.create(_MessageComponent_0_5, projectableNodes);
+    init0Dbg(rootEl, [rootEl]);
+    return new ComponentRef<import2.MessageComponent>(0, this, rootEl, _MessageComponent_0_5);
+  }
+
+  @override
+  void detectChangesInternal() {
+    _compView_0.detectChanges();
+  }
+
+  @override
+  void destroyInternal() {
+    _compView_0?.destroy();
+  }
+}
+
+AppView viewFactory_MessageComponentHost0(AppView<dynamic> parentView, int parentIndex) {
+  return new _ViewMessageComponentHost0(parentView, parentIndex);
+}
+
+const ComponentFactory<import2.MessageComponent> MessageComponentNgFactory = const ComponentFactory<import2.MessageComponent>('message', viewFactory_MessageComponentHost0, _MessageComponentMetadata);
+const _MessageComponentMetadata = const [];
+var _visited = false;
+void initReflector() {
+  if (_visited) {
+    return;
+  }
+  _visited = true;
+
+  _ngRef.registerComponent(MessageComponent, MessageComponentNgFactory);
+  _ref0.initReflector();
+}

--- a/_goldens/test/_files/i18n/message.template_outline.golden
+++ b/_goldens/test/_files/i18n/message.template_outline.golden
@@ -1,0 +1,25 @@
+// ignore_for_file: library_prefixes,unused_import,no_default_super_constructor_explicit,duplicate_import,unused_shown_name
+// The .template.dart files also export the user code.
+export 'message.dart';
+
+// Required for referencing runtime code.
+import 'dart:html';
+import 'package:angular/angular.dart';
+import 'package:angular/src/core/change_detection/directive_change_detector.dart';
+import 'package:angular/src/core/linker/app_view.dart';
+
+// Required for specifically referencing user code.
+import 'message.dart' as _user;
+
+// Required for "type inference" (scoping).
+import 'package:angular/angular.dart';
+
+// For @Component class MessageComponent.
+const List<dynamic> styles$MessageComponent = const [];
+external ComponentFactory get MessageComponentNgFactory;
+external AppView<_user.MessageComponent> viewFactory_MessageComponent0(AppView<dynamic> parentView, num parentIndex);
+class ViewMessageComponent0 extends AppView<_user.MessageComponent> {
+  external ViewMessageComponent0(AppView<dynamic> parentView, num parentIndex);
+}
+
+external void initReflector();

--- a/_goldens/test/_files/i18n/message.template_release.golden
+++ b/_goldens/test/_files/i18n/message.template_release.golden
@@ -1,0 +1,91 @@
+// **************************************************************************
+// Generator: Instance of 'Compiler'
+// **************************************************************************
+
+// ignore_for_file: cancel_subscriptions,constant_identifier_names,duplicate_import,non_constant_identifier_names,library_prefixes,UNUSED_IMPORT,UNUSED_SHOWN_NAME
+import 'message.dart';
+export 'message.dart';
+import 'package:angular/angular.dart';
+import 'package:angular/src/di/reflector.dart' as _ngRef;
+import 'package:angular/angular.template.dart' as _ref0;
+import 'package:angular/src/core/linker/app_view.dart';
+import 'message.dart' as import1;
+import 'dart:html' as import2;
+import 'package:intl/intl.dart' as import3;
+import 'package:angular/src/core/render/api.dart';
+import 'package:angular/src/core/linker/view_type.dart' as import5;
+import 'package:angular/src/core/change_detection/change_detection.dart';
+import 'package:angular/src/core/linker/app_view_utils.dart' as import7;
+import 'package:angular/angular.dart';
+
+const List<dynamic> styles$MessageComponent = const [];
+
+class ViewMessageComponent0 extends AppView<import1.MessageComponent> {
+  import2.Element _el_0;
+  static final String _message_0 = import3.Intl.message('message', desc: 'description');
+  static RenderComponentType _renderType;
+  ViewMessageComponent0(AppView<dynamic> parentView, int parentIndex) : super(import5.ViewType.component, {}, parentView, parentIndex, ChangeDetectionStrategy.CheckAlways) {
+    rootEl = import2.document.createElement('message');
+    _renderType ??= import7.appViewUtils.createRenderType('', ViewEncapsulation.None, styles$MessageComponent);
+    setupComponentType(_renderType);
+  }
+  @override
+  ComponentRef<import1.MessageComponent> build() {
+    final _rootEl = rootEl;
+    final import2.HtmlElement parentRenderNode = initViewRoot(_rootEl);
+    var doc = import2.document;
+    _el_0 = createAndAppend(doc, 'p', parentRenderNode);
+    import2.Text _text_1 = new import2.Text(_message_0);
+    _el_0.append(_text_1);
+    init(const [], null);
+    return null;
+  }
+}
+
+AppView<import1.MessageComponent> viewFactory_MessageComponent0(AppView<dynamic> parentView, int parentIndex) {
+  return new ViewMessageComponent0(parentView, parentIndex);
+}
+
+const List<dynamic> styles$MessageComponentHost = const [];
+
+class _ViewMessageComponentHost0 extends AppView<dynamic> {
+  ViewMessageComponent0 _compView_0;
+  import1.MessageComponent _MessageComponent_0_5;
+  _ViewMessageComponentHost0(AppView<dynamic> parentView, int parentIndex) : super(import5.ViewType.host, {}, parentView, parentIndex, ChangeDetectionStrategy.CheckAlways);
+  @override
+  ComponentRef build() {
+    _compView_0 = new ViewMessageComponent0(this, 0);
+    rootEl = _compView_0.rootEl;
+    _MessageComponent_0_5 = new import1.MessageComponent();
+    _compView_0.create(_MessageComponent_0_5, projectableNodes);
+    init0(rootEl);
+    return new ComponentRef<import1.MessageComponent>(0, this, rootEl, _MessageComponent_0_5);
+  }
+
+  @override
+  void detectChangesInternal() {
+    _compView_0.detectChanges();
+  }
+
+  @override
+  void destroyInternal() {
+    _compView_0?.destroy();
+  }
+}
+
+AppView viewFactory_MessageComponentHost0(AppView<dynamic> parentView, int parentIndex) {
+  return new _ViewMessageComponentHost0(parentView, parentIndex);
+}
+
+const ComponentFactory<import1.MessageComponent> MessageComponentNgFactory = const ComponentFactory<import1.MessageComponent>('message', viewFactory_MessageComponentHost0, _MessageComponentMetadata);
+const _MessageComponentMetadata = const [];
+var _visited = false;
+void initReflector() {
+  if (_visited) {
+    return;
+  }
+  _visited = true;
+
+  _ngRef.registerComponent(MessageComponent, MessageComponentNgFactory);
+  _ref0.initReflector();
+}

--- a/_goldens/tool/src/builder.dart
+++ b/_goldens/tool/src/builder.dart
@@ -19,6 +19,7 @@ Builder debugBuilder(BuilderOptions options) {
     _withoutExtensions(options),
     defaultFlags: const CompilerFlags(
       genDebugInfo: true,
+      i18nEnabled: true,
       ignoreNgPlaceholderForGoldens: true,
     ),
     templateExtension: options.config['extensions']['debug'],
@@ -37,6 +38,7 @@ Builder releaseBuilder(BuilderOptions options) {
     _withoutExtensions(options),
     defaultFlags: const CompilerFlags(
       genDebugInfo: false,
+      i18nEnabled: true,
       ignoreNgPlaceholderForGoldens: true,
     ),
     templateExtension: options.config['extensions']['release'],
@@ -55,6 +57,7 @@ Builder outlineBuilder(BuilderOptions options) {
     _withoutExtensions(options),
     defaultFlags: const CompilerFlags(
       genDebugInfo: false,
+      i18nEnabled: true,
       ignoreNgPlaceholderForGoldens: true,
     ),
     extension: options.config['extensions']['outline'],

--- a/angular/lib/src/compiler/identifiers.dart
+++ b/angular/lib/src/compiler/identifiers.dart
@@ -237,6 +237,12 @@ class Identifiers {
       name: "Event", moduleUrl: "dart:html");
   static final HTML_NODE = new CompileIdentifierMetadata<dynamic>(
       name: "Node", moduleUrl: "dart:html");
+
+  /// A class used for message internationalization.
+  static final Intl = new CompileIdentifierMetadata(
+    name: 'Intl',
+    moduleUrl: 'package:intl/intl.dart',
+  );
 }
 
 CompileTokenMetadata identifierToken(CompileIdentifierMetadata identifier) {

--- a/angular/lib/src/compiler/view_compiler/view_builder.dart
+++ b/angular/lib/src/compiler/view_compiler/view_builder.dart
@@ -99,7 +99,7 @@ class ViewBuilderVisitor implements TemplateAstVisitor<void, CompileElement> {
   void visitText(TextAst ast, CompileElement parent) {
     int nodeIndex = view.nodes.length;
     NodeReference renderNode =
-        view.createTextNode(parent, nodeIndex, ast.value, ast);
+        view.createTextNode(parent, nodeIndex, o.literal(ast.value), ast);
     var compileNode = new CompileNode(parent, view, nodeIndex, renderNode, ast);
     view.nodes.add(compileNode);
     _addRootNodeAndProject(compileNode, ast.ngContentIndex, parent);
@@ -347,8 +347,13 @@ class ViewBuilderVisitor implements TemplateAstVisitor<void, CompileElement> {
 
   @override
   void visitI18nText(I18nTextAst ast, CompileElement parent) {
-    // TODO(leonsenft): render i18n message binding to text.
-    throw new UnimplementedError();
+    final nodeIndex = view.nodes.length;
+    final text = view.createI18nMessage(ast.value);
+    final renderNode = view.createTextNode(parent, nodeIndex, text, ast);
+    final compileNode =
+        new CompileNode(parent, view, nodeIndex, renderNode, ast);
+    view.nodes.add(compileNode);
+    _addRootNodeAndProject(compileNode, ast.ngContentIndex, parent);
   }
 }
 

--- a/angular_compiler/lib/src/cli/flags.dart
+++ b/angular_compiler/lib/src/cli/flags.dart
@@ -171,6 +171,7 @@ class CompilerFlags {
     }
     return new CompilerFlags(
       genDebugInfo: debugMode ?? defaultTo.genDebugInfo,
+      i18nEnabled: defaultTo.i18nEnabled,
       profileFor: _toProfile(profileFor, log) ?? defaultTo.profileFor,
       useLegacyStyleEncapsulation:
           useLegacyStyle ?? defaultTo.useLegacyStyleEncapsulation,


### PR DESCRIPTION
Support for internationalization (i18n) in templates is still a work in progress
and will remain disabled until it is ready for release.