### PR TITLE
feat(Core): loosen restrictions of `Visibility.local`

### DIFF
--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Breaking changes
+
+*   A directive with `Visibility.local` may now be injected by another directive
+    on the same host element, or by a descendant within the same view.
+
 ## 5.0.0-alpha+12
 
 ### Breaking changes

--- a/angular/lib/src/compiler/template_ast.dart
+++ b/angular/lib/src/compiler/template_ast.dart
@@ -297,12 +297,6 @@ class ProviderAst implements TemplateAst {
   /// dependencies.
   final bool visibleForInjection;
 
-  /// Whether the provider is an alias for a directive with local visibility.
-  ///
-  /// This is non-final as it could be changed by another provider overriding
-  /// the original [providers].
-  bool implementedByDirectiveWithNoVisibility;
-
   final List<CompileProviderMetadata> providers;
   final ProviderAstType providerType;
   final SourceSpan sourceSpan;
@@ -317,7 +311,6 @@ class ProviderAst implements TemplateAst {
     this.dynamicallyReachable: true,
     this.typeArgument,
     this.visibleForInjection: true,
-    this.implementedByDirectiveWithNoVisibility: false,
   });
 
   R visit<R, C>(TemplateAstVisitor<R, C> visitor, C context) =>

--- a/angular/lib/src/core/metadata/visibility.dart
+++ b/angular/lib/src/core/metadata/visibility.dart
@@ -4,7 +4,7 @@ import '../metadata.dart';
 ///
 /// See [Directive.visibility] for details including the default behavior.
 enum Visibility {
-  /// The directive can only be injected "locally"; i.e. not by children.
+  /// The directive can only be injected "locally"; i.e. not from another view.
   ///
   /// For example, the following code will fail at runtime:
   /// ```dart
@@ -28,7 +28,43 @@ enum Visibility {
   /// }
   /// ```
   ///
-  /// However, it is possible to provide another interface to children:
+  /// However, if the `Parent` and `Child` components are in the same view, the
+  /// example works:
+  /// ```dart
+  /// @Component(
+  ///   selector: 'parent',
+  ///   template: '',
+  ///
+  ///   // The default, but here explicitly for clarity.
+  ///   visibility: Visibility.local,
+  /// )
+  /// class Parent {}
+  ///
+  /// @Component(
+  ///   selector: 'child',
+  ///   template: '',
+  /// )
+  /// class Child {
+  ///   // Will successfully inject the `Parent` instance.
+  ///   Child(Parent parent);
+  /// }
+  ///
+  /// @Component(
+  ///   selector: 'app',
+  ///   directives: const [Child, Parent],
+  ///   template: '''
+  ///     <parent>
+  ///       <child></child>
+  ///     </parent>
+  ///   ''',
+  /// )
+  /// class App {}
+  /// ```
+  ///
+  /// Similarly, directives on the same host (including a component) can inject
+  /// each other regardless of visibility.
+  ///
+  /// Furthermore, it is possible to provide another interface to children:
   /// ```dart
   /// // An interface that will be provided by the Parent class.
   /// abstract class Example {}


### PR DESCRIPTION
This option now only controls whether code is generated to provide the directive
for injection dynamically. Anywhere the directive instance can be used directly
to satisfy a dependency is now permitted.

This means a directive with `Visibility.local` may now be injected by another
directive on the same host element, or by a descendant within the same view.