### PR TITLE
"pub run build_runner serve" to "webdev serve"

### DIFF
--- a/examples/hacker_news_pwa/README.md
+++ b/examples/hacker_news_pwa/README.md
@@ -11,7 +11,7 @@ It was built as an example for [hnpwa.com](https://hnpwa.com/).
 To run and debug locally using `dartdevc`:
 
 ```console
-$ pub run build_runner serve
+$ webdev serve
 ```
 
 Then navigate to `http://localhost:8080`.


### PR DESCRIPTION
#1341

 https://webdev-dartlang-org-dev.firebaseapp.com/tools/webdev, 
> The webdev tool is built on build_runner and replaces pub build and pub serve. If you’ve previously used build_runner, you should no longer need to use it directly