### PR TITLE
fix(Router): Wrap usages of `.detectChanges()` to avoid a crash.

### DIFF
--- a/angular/lib/src/core/change_detection/host.dart
+++ b/angular/lib/src/core/change_detection/host.dart
@@ -30,6 +30,7 @@ abstract class ChangeDetectionHost {
   /// **INTERNAL ONLY**: Register a crash during [view.detectCrash].
   static void handleCrash(AppView<void> view, Object error, StackTrace trace) {
     final current = _current;
+    assert(current != null);
     current
       .._lastGuardedView = view
       .._lastCaughtException = error

--- a/angular_router/lib/src/detect_changes.dart
+++ b/angular_router/lib/src/detect_changes.dart
@@ -1,0 +1,24 @@
+import 'package:angular/angular.dart';
+import 'package:angular/src/core/change_detection/change_detection.dart';
+import 'package:angular/src/core/change_detection/host.dart';
+import 'package:angular/src/core/linker/view_ref.dart';
+import 'package:angular/src/runtime.dart';
+
+/// Runs [component.changeDetectorRef.detectChanges].
+///
+/// If an error occurs during change detection the component is disabled.
+void safeDetectChanges(ComponentRef<void> component) {
+  // See https://github.com/dart-lang/angular/issues/1354 for details.
+  final viewRef = unsafeCast<ViewRefImpl>(component.hostView);
+  if (viewRef.appView.cdState == ChangeDetectorState.Errored) {
+    return;
+  }
+  try {
+    // Ideally the router would not rely on calling 'detectChanges'.
+    // https://github.com/dart-lang/angular/issues/1356
+    component.changeDetectorRef.detectChanges();
+  } catch (e, s) {
+    final ChangeDetectionHost host = component.injector.get(ApplicationRef);
+    host.reportViewException(viewRef.appView, e, s);
+  }
+}

--- a/angular_router/lib/src/directives/router_outlet_directive.dart
+++ b/angular_router/lib/src/directives/router_outlet_directive.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:angular/angular.dart';
 import 'package:angular/src/runtime.dart';
 
+import '../detect_changes.dart';
 import '../lifecycle.dart';
 import '../route_definition.dart';
 import '../router/router.dart';
@@ -120,7 +121,7 @@ class RouterOutlet implements OnInit, OnDestroy {
       final componentRef = componentFactory.create(new Injector.map({
         RouterOutletToken: new RouterOutletToken(),
       }, _viewContainerRef.injector));
-      componentRef.changeDetectorRef.detectChanges();
+      safeDetectChanges(componentRef);
       return componentRef;
     });
   }
@@ -159,7 +160,7 @@ class RouterOutlet implements OnInit, OnDestroy {
     _activeComponentFactory = componentFactory;
     final component = prepare(componentFactory);
     _viewContainerRef.insert(component.hostView);
-    component.changeDetectorRef.detectChanges();
+    safeDetectChanges(component);
   }
 
   FutureOr<bool> _shouldReuse(

--- a/angular_router/test/regression/1354_routing_state_crash_test.dart
+++ b/angular_router/test/regression/1354_routing_state_crash_test.dart
@@ -1,0 +1,185 @@
+@TestOn('browser')
+import 'dart:async';
+import 'dart:html';
+
+import 'package:angular/angular.dart';
+import 'package:angular_router/angular_router.dart';
+import 'package:angular_router/testing.dart';
+import 'package:test/test.dart';
+
+import '1354_routing_state_crash_test.template.dart' as ng;
+
+void main() {
+  test('should not crash entire app when a routed component throws', () async {
+    final appComponent = runApp<AppComponent>(
+      ng.AppComponentNgFactory,
+      createInjector: ([parent]) {
+        return new Injector.map({
+          ExceptionHandler: new LoggingExceptionHandler(),
+        }, parent);
+      },
+    );
+    Future<void> onStable() => appComponent.instance.onStable;
+
+    E query<E extends Element>(String selector) {
+      return appComponent.location.querySelector(selector) as E;
+    }
+
+    final locationStrategy = appComponent.instance._locationStrategy;
+    final routeContainer = query('.route-container');
+
+    await onStable();
+    expect(_logs, isEmpty);
+    expect(locationStrategy.path(), '/');
+    expect(routeContainer.text, contains('Home Page'));
+
+    // "Navigate" to /another
+    await appComponent.instance.updateUrl('/another');
+    expect(_logs, isEmpty);
+    expect(routeContainer.text, contains('Another Page'));
+
+    // "Navigate" to /throws.
+    await appComponent.instance.updateUrl('/throws');
+    expect(_logs, [contains('$IntentionalException')]);
+    expect(routeContainer.text, contains('Another Page'));
+    _logs.clear();
+
+    // "Navigate" back to /home.
+    await appComponent.instance.updateUrl('/home');
+    expect(_logs, isEmpty);
+    expect(routeContainer.text, contains('Home Page'));
+  });
+}
+
+/// Exceptions that have been caught by the [ExceptionHandler].
+final _logs = <String>[];
+
+class ServiceThatThrows {
+  bool get getterThatThrows {
+    throw new IntentionalException();
+  }
+}
+
+/// A custom [ExceptionHandler] that writes to the top-level [_logs] field.
+class LoggingExceptionHandler implements ExceptionHandler {
+  LoggingExceptionHandler() {
+    _logs.clear();
+  }
+
+  @override
+  void call(exception, [stack, __]) {
+    _logs.add('$exception');
+    window.console.error('$exception\n$stack');
+  }
+}
+
+@Component(
+  selector: 'app',
+  template: r'''
+    <form class="url-form" (submit)="updateUrl(urlBar.value)">
+      <label for="url-bar">Mock URL: </label> 
+      <input #urlBar id="url-bar" [value]="currentUrl" />
+      <button type="submit">Update</button>
+    </form>
+    
+    Navigation:
+    <a routerLink="/home">Home</a> | <a routerLink="/throws">Throws</a>
+
+    Page:
+    <div class="route-container">
+      <router-outlet [routes]="routes"></router-outlet>
+    </div>
+  ''',
+  directives: const [
+    RouterLink,
+    RouterOutlet,
+  ],
+  providers: const [
+    routerProvidersTest,
+    const ClassProvider(ServiceThatThrows),
+  ],
+)
+class AppComponent {
+  static final routes = [
+    new RouteDefinition(
+      path: 'home',
+      useAsDefault: true,
+      component: ng.HomeComponentNgFactory,
+    ),
+    new RouteDefinition(
+      path: 'another',
+      component: ng.AnotherComponentNgFactory,
+    ),
+    new RouteDefinition(
+      path: 'throws',
+      component: ng.ThrowingComponentNgFactory,
+    ),
+  ];
+
+  final MockLocationStrategy _locationStrategy;
+  final NgZone _ngZone;
+  final Testability _testability;
+
+  AppComponent(
+    @Inject(LocationStrategy) this._locationStrategy,
+    this._ngZone,
+    this._testability,
+  );
+
+  String get currentUrl => _locationStrategy.path();
+
+  /// Returns a future that completes when [Testability] reports stability.
+  Future<void> get onStable async {
+    // Await an artificial amount of extra time.
+    await new Future.delayed(Duration.zero);
+
+    // Then wait for an async completion.
+    final completer = new Completer<void>();
+    _testability.whenStable((_) => completer.complete());
+    return completer.future;
+  }
+
+  /// Updates the application [LocationStrategy] as-if the URL was changed.
+  ///
+  /// Can also be used as a poor-man's stability API.
+  ///
+  /// Returns a [Future] that completes (a) after changing and (b) after stable.
+  Future<void> updateUrl(String newUrl) {
+    // Enters the zone manually if needed.
+    return _ngZone.run((() {
+      _locationStrategy.simulatePopState(newUrl);
+      return onStable;
+    }));
+  }
+}
+
+@Component(
+  selector: 'home',
+  template: 'Home Page',
+)
+class HomeComponent {}
+
+@Component(
+  selector: 'another',
+  template: 'Another Page',
+)
+class AnotherComponent {}
+
+@Component(
+  selector: 'throws',
+  directives: const [
+    NgIf,
+  ],
+  template: r'''a
+    <ng-container *ngIf="service.getterThatThrows">
+      Should not be shown.
+    </ng-container>
+  ''',
+)
+class ThrowingComponent {
+  final ServiceThatThrows service;
+
+  ThrowingComponent(this.service);
+}
+
+class IntentionalException implements Exception {}

--- a/angular_router/test/regression/1354_routing_state_crash_test.dart
+++ b/angular_router/test/regression/1354_routing_state_crash_test.dart
@@ -41,10 +41,10 @@ void main() {
     // "Navigate" to /throws.
     await appComponent.instance.updateUrl('/throws');
     expect(_logs, [contains('$IntentionalException')]);
-    expect(routeContainer.text, contains('Another Page'));
-    _logs.clear();
+    expect(routeContainer.text, isEmpty);
 
     // "Navigate" back to /home.
+    _logs.clear();
     await appComponent.instance.updateUrl('/home');
     expect(_logs, isEmpty);
     expect(routeContainer.text, contains('Home Page'));
@@ -68,8 +68,13 @@ class LoggingExceptionHandler implements ExceptionHandler {
 
   @override
   void call(exception, [stack, __]) {
-    _logs.add('$exception');
-    window.console.error('$exception\n$stack');
+    _logs.add('$exception: $stack');
+
+    if (exception is! IntentionalException) {
+      window.console.error('$exception\n$stack');
+    } else {
+      window.console.info('ExceptionHandler caught the intentional exception');
+    }
   }
 }
 
@@ -83,7 +88,9 @@ class LoggingExceptionHandler implements ExceptionHandler {
     </form>
     
     Navigation:
-    <a routerLink="/home">Home</a> | <a routerLink="/throws">Throws</a>
+    <a routerLink="/home">Home</a> | 
+    <a routerLink="/throws">Throws</a> |
+    <a routerLink="/another">Another</a>
 
     Page:
     <div class="route-container">
@@ -170,7 +177,7 @@ class AnotherComponent {}
   directives: const [
     NgIf,
   ],
-  template: r'''a
+  template: r'''
     <ng-container *ngIf="service.getterThatThrows">
       Should not be shown.
     </ng-container>


### PR DESCRIPTION
Closes https://github.com/dart-lang/angular/issues/1354.