### PR TITLE
chore(Repo): fix exclude globs and indentation

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,19 +1,19 @@
 analyzer:
- strong-mode: true
- errors:
-   unused_element: error
-   unused_import: error
-   unused_local_variable: error
-   dead_code: error
+  strong-mode: true
+  errors:
+    unused_element: error
+    unused_import: error
+    unused_local_variable: error
+    dead_code: error
 
-   # Allow importing .template.dart files without an analyzer error.
-   uri_has_not_been_generated: ignore
+    # Allow importing .template.dart files without an analyzer error.
+    uri_has_not_been_generated: ignore
 
-   # The noise of deprecations isn't worth the effort.
-   deprecated_member_use: ignore
- exclude:
-   - "**/.dart_tool/**"
-   - "**/build/**"
+    # The noise of deprecations isn't worth the effort.
+    deprecated_member_use: ignore
+  exclude:
+    - .dart_tool/**
+    - build/**
 
 linter:
   rules:

--- a/angular/analysis_options.yaml
+++ b/angular/analysis_options.yaml
@@ -1,21 +1,21 @@
 # This is a copy of ../analysis_options.yaml, with implicit-casts: false, and an "exclude: ...".
 
 analyzer:
- strong-mode:
-   implicit-casts: false
- exclude:
+  strong-mode:
+    implicit-casts: false
+  exclude:
     - "tools/analyzer_plugin/bin/plugin.dart"
- errors:
-   unused_element: error
-   unused_import: error
-   unused_local_variable: error
-   dead_code: error
+  errors:
+    unused_element: error
+    unused_import: error
+    unused_local_variable: error
+    dead_code: error
 
-   # Allow importing .template.dart files without an analyzer error.
-   uri_has_not_been_generated: ignore
+    # Allow importing .template.dart files without an analyzer error.
+    uri_has_not_been_generated: ignore
 
-   # The noise of deprecations isn't worth the effort.
-   deprecated_member_use: ignore
+    # The noise of deprecations isn't worth the effort.
+    deprecated_member_use: ignore
 linter:
   rules:
     - avoid_empty_else


### PR DESCRIPTION
The `build/` directory wasn't being excluded from analysis in Visual Studio
Code. It's worth noting it was properly excluded from analysis in IntelliJ.
It's unclear whether this is due to their respective Dart plugins matching
against different paths or if IntelliJ was already excluding `build/`
directories by default.

The fix ensures that the `build/` directory is properly excluded in all cases.
Since analysis is performed at the package level (rather than where the
analysis_options.yaml file is found), the leading `**` was unnecessary anyways.

Also adjusted indentation to consistently use 2 spaces in both files.