### PR TITLE
fix(Core): prevent crash caused by sequence of [ngTemplateOutlet] inputs

### DIFF
--- a/_tests/test/regression/1382_ng_template_outlet_test.dart
+++ b/_tests/test/regression/1382_ng_template_outlet_test.dart
@@ -1,0 +1,44 @@
+@TestOn('browser')
+import 'package:angular/angular.dart';
+import 'package:angular_test/angular_test.dart';
+import 'package:test/test.dart';
+
+import '1382_ng_template_outlet_test.template.dart' as ng;
+
+void main() {
+  test('should not crash setting and resetting [ngTemplateOutlet]', () async {
+    final testBed =
+        NgTestBed.forComponent<TestComponent>(ng.TestComponentNgFactory);
+    final testFixture = await testBed.create();
+    await testFixture.update((component) {
+      // This sets the active view within `NgTemplateOutlet`.
+      component.activeTemplate = component.greetingTemplate;
+    });
+    expect(testFixture.text.trim(), 'Hello world!');
+    await testFixture.update((component) {
+      // This incorrectly wouldn't invalidate the active view.
+      component.activeTemplate = null;
+    });
+    expect(testFixture.text.trim(), isEmpty);
+    await testFixture.update((component) {
+      // This would attempt to remove the previously active view a second time
+      // and crash.
+      component.activeTemplate = component.greetingTemplate;
+    });
+    expect(testFixture.text.trim(), 'Hello world!');
+  });
+}
+
+@Component(
+  selector: 'test',
+  template: '''
+    <template #greeting>Hello world!</template>
+    <ng-container *ngTemplateOutlet="activeTemplate"></ng-container>
+  ''',
+  directives: const [NgTemplateOutlet],
+)
+class TestComponent {
+  @ViewChild('greeting')
+  TemplateRef greetingTemplate;
+  TemplateRef activeTemplate;
+}

--- a/angular/lib/src/common/directives/ng_template_outlet.dart
+++ b/angular/lib/src/common/directives/ng_template_outlet.dart
@@ -62,6 +62,8 @@ class NgTemplateOutlet implements DoCheck {
     }
     if (templateRef != null) {
       _insertedViewRef = _viewContainerRef.createEmbeddedView(templateRef);
+    } else {
+      _insertedViewRef = null;
     }
   }
 


### PR DESCRIPTION
`NgTemplateOutlet` would not invalidate its active view reference when
`[ngTemplateOutlet]` was passed null, thus a specific sequence of inputs could
cause it to crash when attempting to remove a previously removed view reference.

Fixes https://github.com/dart-lang/angular/issues/1382.