### PR TITLE
fix(Router): fail navigation to '/' if there's no matching route

### DIFF
--- a/angular_router/CHANGELOG.md
+++ b/angular_router/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Bug fixes
+
+*   Navigation will no longer succeed for an empty path if it doesn't match a
+    route.
+
 ## 2.0.0-alpha+13
 
 ### New features

--- a/angular_router/lib/src/router/router_impl.dart
+++ b/angular_router/lib/src/router/router_impl.dart
@@ -182,7 +182,9 @@ class RouterImpl extends Router {
     }
 
     MutableRouterState nextState = await _resolveState(path, navigationParams);
-    if (nextState == null) {
+    // In the event that `path` is empty and doesn't match any routes,
+    // `_resolveState` will return a state with no routes, instead of null.
+    if (nextState == null || nextState.routes.isEmpty) {
       return NavigationResult.INVALID_ROUTE;
     }
 

--- a/angular_router/test/regression/1389_empty_path_test.dart
+++ b/angular_router/test/regression/1389_empty_path_test.dart
@@ -1,0 +1,33 @@
+@TestOn('browser')
+import 'package:angular/angular.dart';
+import 'package:angular_router/angular_router.dart';
+import 'package:angular_router/testing.dart';
+import 'package:angular_test/angular_test.dart';
+import 'package:test/test.dart';
+
+// ignore: uri_has_not_been_generated
+import '1389_empty_path_test.template.dart' as ng;
+
+void main() {
+  tearDown(disposeAnyRunningTest);
+
+  test('navigation to empty path should fail', () async {
+    final testBed =
+        NgTestBed.forComponent<TestComponent>(ng.TestComponentNgFactory);
+    final testFixture = await testBed.create();
+    final router = testFixture.assertOnlyInstance.router;
+    final result = await router.navigate('/');
+    expect(result, NavigationResult.INVALID_ROUTE);
+  });
+}
+
+@Component(
+  selector: 'test',
+  template: '',
+  providers: routerProvidersTest,
+)
+class TestComponent {
+  final Router router;
+
+  TestComponent(this.router);
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/angular/issues/1389.