### PR TITLE
chore(i18n): add hidden flag to enable i18n for tests

### DIFF
--- a/_tests/build.yaml
+++ b/_tests/build.yaml
@@ -14,3 +14,4 @@ targets:
       angular:
         options:
           debug: True
+          i18n: True

--- a/angular_compiler/lib/src/cli/flags.dart
+++ b/angular_compiler/lib/src/cli/flags.dart
@@ -9,6 +9,7 @@ const _argLegacyStyle = 'use_legacy_style_encapsulation';
 
 // Experimental flags (not published).
 const _argForceMinifyWhitespace = 'force-minify-whitespace';
+const _argI18nEnabled = 'i18n';
 const _argNoEmitComponentFactories = 'no-emit-component-factories';
 const _argNoEmitInjectableFactories = 'no-emit-injectable-factories';
 
@@ -46,6 +47,11 @@ class CompilerFlags {
     )
     ..addFlag(
       _argForceMinifyWhitespace,
+      defaultsTo: null,
+      hide: true,
+    )
+    ..addFlag(
+      _argI18nEnabled,
       defaultsTo: null,
       hide: true,
     )
@@ -152,6 +158,7 @@ class CompilerFlags {
     if (options is Map) {
       final knownArgs = const [
         _argDebugMode,
+        _argI18nEnabled,
         _argProfileFor,
         _argLegacyStyle,
         _argForceMinifyWhitespace,
@@ -170,6 +177,7 @@ class CompilerFlags {
     }
 
     final debugMode = options[_argDebugMode];
+    final i18nEnabled = options[_argI18nEnabled];
     final profileFor = options[_argProfileFor];
     final useLegacyStyle = options[_argLegacyStyle];
     final forceMinifyWhitespace = options[_argForceMinifyWhitespace];
@@ -178,7 +186,7 @@ class CompilerFlags {
 
     return new CompilerFlags(
       genDebugInfo: debugMode ?? defaultTo.genDebugInfo,
-      i18nEnabled: defaultTo.i18nEnabled,
+      i18nEnabled: i18nEnabled ?? defaultTo.i18nEnabled,
       profileFor: _toProfile(profileFor, log) ?? defaultTo.profileFor,
       useLegacyStyleEncapsulation:
           useLegacyStyle ?? defaultTo.useLegacyStyleEncapsulation,


### PR DESCRIPTION
Internalization (i18n) in templates is still a work in progress and will remain
disabled until it's ready for release.