### PR TITLE
chore: base setup for use of API doc code-excerpt updating tools

### DIFF
--- a/angular/lib/src/common/directives/ng_if.dart
+++ b/angular/lib/src/common/directives/ng_if.dart
@@ -10,17 +10,33 @@ import 'package:angular/src/core/linker/app_view_utils.dart';
 ///
 /// ### Examples
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.html (NgIf-1)"?>
+/// <?code-excerpt "examples/hacker_news_pwa/lib/src/item_detail_component.html"?>
 /// ```html
-/// <hero-detail *ngIf="isActive"></hero-detail>
+/// <!-- Loading view -->
+/// <div *ngIf="item == null" class="notice">Loading...</div>
+///
+/// <!-- Loaded view -->
+/// <template [ngIf]="item != null">
+///   <item [item]="item"></item>
+///   <div *ngIf="item['comments'].isEmpty">There are no comments yet.</div>
+///   <comment
+///       *ngFor="let comment of item['comments']"
+///       [comment]="comment">
+///   </comment>
+/// </template>
 /// ```
 ///
-/// <?code-excerpt "docs/structural-directives/lib/app_component.html (asterisk)"?>
+/// <?code-excerpt "packages/template_syntax/app_component.html (NgIf-1)"?>
+/// ```html
+/// <my-hero *ngIf="isActive"></my-hero>
+/// ```
+///
+/// <?code-excerpt "packages/structural_directives/app_component.html (asterisk)"?>
 /// ```html
 /// <div *ngIf="hero != null" >{{hero.name}}</div>
 /// ```
 ///
-/// <?code-excerpt "docs/structural-directives/lib/app_component.html (ngif-template)"?>
+/// <?code-excerpt "packages/structural_directives/app_component.html (ngif-template)"?>
 /// ```html
 /// <template [ngIf]="hero != null">
 ///   <div>{{hero.name}}</div>

--- a/angular_forms/lib/src/directives/ng_model.dart
+++ b/angular_forms/lib/src/directives/ng_model.dart
@@ -30,14 +30,14 @@ import 'shared.dart' show setUpControl;
 ///
 /// ### Examples
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.html (NgModel-1)"?>
+/// <?code-excerpt "packages/template_syntax/app_component.html (NgModel-1)"?>
 /// ```html
 /// <input [(ngModel)]="currentHero.name">
 /// ```
 ///
 /// This is equivalent to having separate bindings:
 ///
-/// <?code-excerpt "docs/template-syntax/lib/app_component.html (NgModel-3)"?>
+/// <?code-excerpt "packages/template_syntax/app_component.html (NgModel-3)"?>
 /// ```html
 /// <input
 ///   [ngModel]="currentHero.name"

--- a/build.excerpt.yaml
+++ b/build.excerpt.yaml
@@ -1,0 +1,11 @@
+targets:
+  $default:
+    sources:
+      include:
+        - examples/**
+      exclude:
+        - '**/.*/**'
+        - '**/build/**'
+    builders:
+      code_excerpter|code_excerpter:
+        enabled: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,5 +5,24 @@
 name: repository
 
 dev_dependencies:
+  build_runner: any
+  code_excerpter:
+    git: https://github.com/chalin/code_excerpter.git
+  code_excerpt_updater:
+    git: https://github.com/chalin/code_excerpt_updater.git
   dev:
     path: dev
+
+  # Source of some of the code examples
+  structural_directives:
+    git:
+      url: https://github.com/dart-lang/site-webdev.git
+      path: examples/ng/doc/structural-directives
+  template_syntax:
+    git:
+      url: https://github.com/dart-lang/site-webdev.git
+      path: examples/ng/doc/template-syntax
+  pipes:
+    git:
+      url: https://github.com/dart-lang/site-webdev.git
+      path: examples/ng/api/common/pipes


### PR DESCRIPTION
This PR illustrates how to use two Dart tools to update code excerpts in API docs. The hope is that these tools can be used both internally and externally.

TL;DR

---

The two tools used to refresh code excerpts in the site-webdev and site-www docs are now written in Dart:

- https://github.com/chalin/code_excerpter is written as a builder. It scans source files for `#docregion` markers and creates `*.excerpt.yaml` excerpt files from the named regions.
- https://github.com/chalin/code_excerpt_updater can be run using `pub run`. Using the generated excerpt files, this tool scans the docs, refreshing any outdates excerpts as needed.

This PR illustrates the base setup for use of the tools. The tools are simply listed as `dev_dependencies` in the top-level `pubspec.yaml`.

This is how you can generate the code-excerpts from sources (both the local `examples/**` and the site-webdev example apps):

```console
pub upgrade 
pub run build_runner build --delete-conflicting-outputs --config excerpt --output tmp/excerpt
```

I've had to configure the builder to run over all packages, so the first build takes 22s (because some of the site-webdev example apps use ACX), but its 2s after that.

To update code excerpts in API docs, you can run commands like the following for `angular_forms`:

```console
pub run code_excerpt_updater \
  --no-escape-ng-interpolation \
  --fail-on-refresh \
  --write-in-place \
  --src-dir-path tmp/excerpt \
  --fragment-dir-path tmp/excerpt \
  --yaml angular_forms
```

You can update entire packages or individual files/folders:

```console
pub run code_excerpt_updater --no-escape-ng-interpolation --fail-on-refresh --write-in-place --src-dir-path tmp/excerpt --fragment-dir-path tmp/excerpt --yaml angular/lib/src/common/directives/ng_if.dart
```

I've run both of these commands and included the resulting changes in this PR.

Hopefully these two tools could be used both internally and externally, potentially contributing to solutions for the following issues:

- Validate that code snippets in docs are at least "analyzer clean" #996 
- Test & update/remove the examples in the API docs #1267
- Should docs and examples for webdev.dartlang live here? #942
- API docs: OnInit has inlined code and no longer links to Lifecycle docs #602
- Update documentation for Query.read to include an example #249

cc @alorenzen @matanlurey @kwalrath @kevmoo 