### PR TITLE
test(i18n): test translation of template messages

### DIFF
--- a/_tests/pubspec.yaml
+++ b/_tests/pubspec.yaml
@@ -24,6 +24,7 @@ dev_dependencies:
   build_runner: ^0.8.0
   build_test: ^0.10.2+1
   build_web_compilers: ^0.4.0
+  intl: ^0.15.6
   mockito: '>=0.11.0 <3.0.0'
   source_span: ^1.4.0
 

--- a/_tests/test/core/i18n_test.dart
+++ b/_tests/test/core/i18n_test.dart
@@ -1,6 +1,10 @@
 @TestOn('browser')
 import 'package:angular/angular.dart';
 import 'package:angular_test/angular_test.dart';
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+// Normally imported by the message files generated for each locale.
+import 'package:intl/src/intl_helpers.dart';
 import 'package:test/test.dart';
 
 import 'i18n_test.template.dart' as ng;
@@ -8,11 +12,19 @@ import 'i18n_test.template.dart' as ng;
 void main() {
   tearDown(disposeAnyRunningTest);
 
+  setUpAll(() async {
+    Intl.defaultLocale = 'fr';
+    // Initialize manual translations. Don't do this in production; this is a
+    // shortcut to avoid dealing with file I/O in this test.
+    initializeInternalMessageLookup(() => new CompositeMessageLookup());
+    messageLookup.addLocale('fr', (_) => new MessageLookupForFr());
+  });
+
   test('should render message', () async {
     final testBed =
         NgTestBed.forComponent<TestI18nNode>(ng.TestI18nNodeNgFactory);
     final testFixture = await testBed.create();
-    expect(testFixture.text, 'A message.');
+    expect(testFixture.text, 'Un message.');
   });
 
   test('should render message in attribute', () async {
@@ -20,26 +32,46 @@ void main() {
         .forComponent<TestI18nAttribute>(ng.TestI18nAttributeNgFactory);
     final testFixture = await testBed.create();
     final imgElement = testFixture.rootElement.querySelector('img');
-    expect(imgElement.getAttribute('alt'), 'A puppy!');
+    expect(imgElement.getAttribute('alt'), 'Un chiot!');
   });
 
   test('should render message with HTML', () async {
     final testBed = NgTestBed
         .forComponent<TestI18nNodeWithHtml>(ng.TestI18nNodeWithHtmlNgFactory);
     final testFixture = await testBed.create();
-    expect(testFixture.text, 'A message with emphasis!');
+    expect(testFixture.text, 'Un message avec emphase!');
     final strongElement = testFixture.rootElement.querySelector('strong');
-    expect(strongElement.text, 'emphasis!');
+    expect(strongElement.text, 'emphase!');
   });
 
   test('should render message with unsafe HTML', () async {
     final testBed = NgTestBed.forComponent<TestI18nNodeWithUnsafeHtml>(
         ng.TestI18nNodeWithUnsafeHtmlNgFactory);
     final testFixture = await testBed.create();
-    expect(testFixture.text, 'Click here to file an issue.');
+    expect(testFixture.text, 'Cliquez ici pour signaler un problème.');
     final anchorElement = testFixture.rootElement.querySelector('a');
+    expect(anchorElement.text, 'ici');
     expect(anchorElement.getAttribute('href'), issuesLink);
   });
+}
+
+class MessageLookupForFr extends MessageLookupByLibrary {
+  @override
+  String get localeName => 'fr';
+
+  static String m0(startTag0, endTag0) =>
+      'Un message avec ${startTag0}emphase!$endTag0';
+
+  static String m1(startTag0, endTag0) =>
+      'Cliquez ${startTag0}ici$endTag0 pour signaler un problème.';
+
+  @override
+  final Map<String, dynamic> messages = {
+    'A message.': MessageLookupByLibrary.simpleMessage('Un message.'),
+    'A puppy!': MessageLookupByLibrary.simpleMessage('Un chiot!'),
+    'ViewTestI18nNodeWithHtml0_message_0': m0,
+    'ViewTestI18nNodeWithUnsafeHtml0_message_0': m1,
+  };
 }
 
 const issuesLink = 'https://github.com/dart-lang/angular/issues';


### PR DESCRIPTION
Internalization (i18n) in templates is still a work in progress and will remain
disabled until it's ready for release.