### PR TITLE
fix(Compiler): replace `retype()` with `cast()`

### DIFF
--- a/angular/lib/src/compiler/view_compiler/expression_converter.dart
+++ b/angular/lib/src/compiler/view_compiler/expression_converter.dart
@@ -215,7 +215,7 @@ class _AstToIrVisitor implements compiler_ast.AstVisitor<dynamic, _Mode> {
   dynamic visitPipe(compiler_ast.BindingPipe ast, _Mode mode) {
     _visitingRoot = false;
     var input = ast.exp.visit<dynamic, _Mode>(this, _Mode.Expression);
-    var args = _visitAll(ast.args, _Mode.Expression).retype<o.Expression>();
+    var args = _visitAll(ast.args, _Mode.Expression).cast<o.Expression>();
     var value = _nameResolver.callPipe(ast.name, input, args);
     return _convertToStatementIfNeeded(mode, value);
   }
@@ -225,7 +225,7 @@ class _AstToIrVisitor implements compiler_ast.AstVisitor<dynamic, _Mode> {
     return _convertToStatementIfNeeded(
         mode,
         ast.target.visit<dynamic, _Mode>(this, _Mode.Expression).callFn(
-            _visitAll(ast.args, _Mode.Expression).retype<o.Expression>()));
+            _visitAll(ast.args, _Mode.Expression).cast<o.Expression>()));
   }
 
   dynamic visitIfNull(compiler_ast.IfNull ast, _Mode mode) {
@@ -327,7 +327,7 @@ class _AstToIrVisitor implements compiler_ast.AstVisitor<dynamic, _Mode> {
     return _convertToStatementIfNeeded(
       mode,
       _nameResolver.createLiteralList(
-          _visitAll(ast.expressions, mode).retype<o.Expression>(),
+          _visitAll(ast.expressions, mode).cast<o.Expression>(),
           type: isRootExpression ? _boundType : null),
     );
   }
@@ -355,7 +355,7 @@ class _AstToIrVisitor implements compiler_ast.AstVisitor<dynamic, _Mode> {
 
   dynamic visitMethodCall(compiler_ast.MethodCall ast, _Mode mode) {
     _visitingRoot = false;
-    var args = _visitAll(ast.args, _Mode.Expression).retype<o.Expression>();
+    var args = _visitAll(ast.args, _Mode.Expression).cast<o.Expression>();
     o.Expression result;
     o.Expression receiver =
         ast.receiver.visit<dynamic, _Mode>(this, _Mode.Expression);
@@ -420,7 +420,7 @@ class _AstToIrVisitor implements compiler_ast.AstVisitor<dynamic, _Mode> {
   dynamic visitSafeMethodCall(compiler_ast.SafeMethodCall ast, _Mode mode) {
     _visitingRoot = false;
     var receiver = ast.receiver.visit<dynamic, _Mode>(this, _Mode.Expression);
-    var args = _visitAll(ast.args, _Mode.Expression).retype<o.Expression>();
+    var args = _visitAll(ast.args, _Mode.Expression).cast<o.Expression>();
     return _convertToStatementIfNeeded(
         mode,
         receiver

--- a/angular/lib/src/source_gen/template_compiler/compile_metadata.dart
+++ b/angular/lib/src/source_gen/template_compiler/compile_metadata.dart
@@ -53,7 +53,7 @@ class CompileTypeMetadataVisitor
   /// Otherwise, use the first encountered.
   ConstructorElement unnamedConstructor(ClassElement element) {
     ConstructorElement constructor;
-    final constructors = element.constructors.retype<ConstructorElement>();
+    final constructors = element.constructors.cast<ConstructorElement>();
     if (constructors.isEmpty) {
       BuildError.throwForElement(element, 'No constructors found');
     }


### PR DESCRIPTION
The `retype()` method was removed in Dart 2.0.0-dev.62.0.