### PR TITLE
feat(Compiler): Support conditional attributes.

### DIFF
--- a/_goldens/build.yaml
+++ b/_goldens/build.yaml
@@ -14,7 +14,7 @@ targets:
 builders:
   goldens:
     target: "goldens"
-    import: "../../../tool/src/builder.dart"
+    import: "tool/src/builder.dart"
     builder_factories:
       - releaseBuilder
       - outlineBuilder

--- a/_goldens/test/_files/host.dart
+++ b/_goldens/test/_files/host.dart
@@ -32,6 +32,7 @@ class HostComponent {
   @HostBinding('attr.aria-title')
   String get title => 'Hello';
 
+  @HostBinding('attr.aria-disabled.if')
   @HostBinding('class.is-disabled')
   bool get isDisabled => true;
 

--- a/_goldens/test/_files/host.template.golden
+++ b/_goldens/test/_files/host.template.golden
@@ -205,7 +205,7 @@ class ViewHostComponent0 extends AppView<import1.HostComponent> {
     }
     final currVal_2 = ctx.isDisabled;
     if (import6.checkBinding(_expr_2, currVal_2)) {
-      setAttr(rootEl, 'aria-disabled', (identical(currVal_2, true) ? '' : null));
+      setAttr(rootEl, 'aria-disabled', (currVal_2 ? '' : null));
       _expr_2 = currVal_2;
     }
     final currVal_3 = ctx.isDisabled;

--- a/_goldens/test/_files/host.template.golden
+++ b/_goldens/test/_files/host.template.golden
@@ -165,7 +165,8 @@ final List<dynamic> styles$HostComponent = const [];
 class ViewHostComponent0 extends AppView<import1.HostComponent> {
   var _expr_0;
   var _expr_1;
-  bool _expr_2;
+  var _expr_2;
+  bool _expr_3;
   static RenderComponentType _renderType;
   ViewHostComponent0(AppView<dynamic> parentView, int parentIndex) : super(import3.ViewType.component, {}, parentView, parentIndex, ChangeDetectionStrategy.CheckAlways) {
     rootEl = import5.document.createElement('host');
@@ -204,8 +205,13 @@ class ViewHostComponent0 extends AppView<import1.HostComponent> {
     }
     final currVal_2 = ctx.isDisabled;
     if (import6.checkBinding(_expr_2, currVal_2)) {
-      updateElemClass(rootEl, 'is-disabled', currVal_2);
+      setAttr(rootEl, 'aria-disabled', (identical(currVal_2, true) ? '' : null));
       _expr_2 = currVal_2;
+    }
+    final currVal_3 = ctx.isDisabled;
+    if (import6.checkBinding(_expr_3, currVal_3)) {
+      updateElemClass(rootEl, 'is-disabled', currVal_3);
+      _expr_3 = currVal_3;
     }
   }
 }

--- a/_tests/test/compiler/ast_template_parser_test.dart
+++ b/_tests/test/compiler/ast_template_parser_test.dart
@@ -159,7 +159,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Property,
+              PropertyBindingType.property,
               'someProp',
               'v',
               null
@@ -172,7 +172,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Property,
+              PropertyBindingType.property,
               'some-prop',
               'v',
               null
@@ -185,7 +185,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Property,
+              PropertyBindingType.property,
               'mappedProp',
               'v',
               null
@@ -198,7 +198,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Attribute,
+              PropertyBindingType.attribute,
               'someAttr',
               'v',
               null
@@ -212,7 +212,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Class,
+              PropertyBindingType.cssClass,
               'some-class',
               'v',
               null
@@ -226,7 +226,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Class,
+              PropertyBindingType.cssClass,
               'someClass',
               'v',
               null
@@ -240,7 +240,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Style,
+              PropertyBindingType.style,
               'someStyle',
               'v',
               null
@@ -282,7 +282,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Property,
+              PropertyBindingType.property,
               'prop',
               'v',
               null
@@ -297,7 +297,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Property,
+              PropertyBindingType.property,
               'prop',
               'v',
               null
@@ -312,7 +312,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Property,
+              PropertyBindingType.property,
               'prop',
               '{{ v }}',
               null
@@ -385,7 +385,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Property,
+              PropertyBindingType.property,
               'prop',
               'v',
               null
@@ -439,14 +439,14 @@ void main() {
                 [AttrAst, 'b', ''],
                 [
                   BoundElementPropertyAst,
-                  PropertyBindingType.Property,
+                  PropertyBindingType.property,
                   'a',
                   'foo',
                   null
                 ],
                 [
                   BoundElementPropertyAst,
-                  PropertyBindingType.Property,
+                  PropertyBindingType.property,
                   'b',
                   'bar',
                   null
@@ -470,7 +470,7 @@ void main() {
             [ElementAst, 'div'],
             [
               BoundElementPropertyAst,
-              PropertyBindingType.Property,
+              PropertyBindingType.property,
               'a',
               'b',
               null
@@ -1951,7 +1951,7 @@ void main() {
               [ElementAst, 'div', '<div [someProp]="v">'],
               [
                 BoundElementPropertyAst,
-                PropertyBindingType.Property,
+                PropertyBindingType.property,
                 'someProp',
                 'v',
                 null,

--- a/_tests/test/core/host_annotation_test.dart
+++ b/_tests/test/core/host_annotation_test.dart
@@ -89,12 +89,15 @@ void main() {
       final fixture = await testBed.create();
       final element = fixture.rootElement;
       expect(element.attributes.containsKey('disabled'), isFalse);
+      expect(element.attributes.containsKey('aria-disabled'), isFalse);
 
       await fixture.update((c) => c.disabledBackingValue = true);
       expect(element.attributes.containsKey('disabled'), isTrue);
+      expect(element.attributes.containsKey('aria-disabled'), isTrue);
 
       await fixture.update((c) => c.disabledBackingValue = false);
       expect(element.attributes.containsKey('disabled'), isFalse);
+      expect(element.attributes.containsKey('aria-disabled'), isFalse);
     });
 
     test('should support conditional classes', () async {
@@ -228,9 +231,12 @@ class HostBindingInstanceClass {
   template: '',
 )
 class HostBindingConditionalAttribute {
+  // Old Style
   @HostBinding('attr.disabled')
   String get disabled => disabledBackingValue ? 'disabled' : null;
 
+  // New Style
+  @HostBinding('attr.aria-disabled.if')
   bool disabledBackingValue = false;
 }
 

--- a/angular/lib/src/compiler/template_ast.dart
+++ b/angular/lib/src/compiler/template_ast.dart
@@ -361,16 +361,16 @@ class NgContentAst implements TemplateAst {
 /// Enumeration of types of property bindings.
 enum PropertyBindingType {
   /// A normal binding to a property (e.g. [property]='expression').
-  Property,
+  property,
 
   /// A binding to an element attribute (e.g. [attr.name]='expression').
-  Attribute,
+  attribute,
 
   /// A binding to a CSS class (e.g. [class.name]='condition').
-  Class,
+  cssClass,
 
   /// A binding to a style rule (e.g. [style.rule]='expression').
-  Style
+  style
 }
 
 /// A visitor for [TemplateAst] trees that will process each node.

--- a/angular/lib/src/compiler/template_parser.dart
+++ b/angular/lib/src/compiler/template_parser.dart
@@ -90,7 +90,7 @@ BoundElementPropertyAst createElementPropertyAst(
     boundPropertyName = schemaRegistry.getMappedPropName(parts[0]);
     securityContext =
         schemaRegistry.securityContext(elementName, boundPropertyName);
-    bindingType = PropertyBindingType.Property;
+    bindingType = PropertyBindingType.property;
     if (!schemaRegistry.hasProperty(elementName, boundPropertyName)) {
       if (boundPropertyName == 'ngclass') {
         reportError(
@@ -114,6 +114,10 @@ BoundElementPropertyAst createElementPropertyAst(
             '(${boundPropertyName.substring(2)})=...',
             sourceSpan);
       }
+      unit = parts.length > 2 ? parts[2] : null;
+      if (unit != null && unit != 'if') {
+        reportError('Invalid attribute unit "$unit"', sourceSpan);
+      }
       // NB: For security purposes, use the mapped property name, not the
       // attribute name.
       securityContext = schemaRegistry.securityContext(
@@ -124,24 +128,30 @@ BoundElementPropertyAst createElementPropertyAst(
         var name = boundPropertyName.substring(nsSeparatorIdx + 1);
         boundPropertyName = mergeNsAndName(ns, name);
       }
-      bindingType = PropertyBindingType.Attribute;
+      bindingType = PropertyBindingType.attribute;
     } else if (parts[0] == _classPrefix) {
       boundPropertyName = parts[1];
-      bindingType = PropertyBindingType.Class;
+      bindingType = PropertyBindingType.cssClass;
       securityContext = TemplateSecurityContext.none;
     } else if (parts[0] == _stylePrefix) {
       unit = parts.length > 2 ? parts[2] : null;
       boundPropertyName = parts[1];
-      bindingType = PropertyBindingType.Style;
+      bindingType = PropertyBindingType.style;
       securityContext = TemplateSecurityContext.style;
     } else {
-      reportError("Invalid property name '$name'", sourceSpan);
+      reportError('Invalid property name "$name"', sourceSpan);
       bindingType = null;
       securityContext = null;
     }
   }
-  return new BoundElementPropertyAst(boundPropertyName, bindingType,
-      securityContext, valueExpr, unit, sourceSpan);
+  return new BoundElementPropertyAst(
+    boundPropertyName,
+    bindingType,
+    securityContext,
+    valueExpr,
+    unit,
+    sourceSpan,
+  );
 }
 
 List<String> _splitClasses(String classAttrValue) {

--- a/angular/lib/src/compiler/view_compiler/property_binder.dart
+++ b/angular/lib/src/compiler/view_compiler/property_binder.dart
@@ -264,9 +264,7 @@ void bindAndWriteToRenderer(
             // For now we treat this as a pure transform to make the
             // implementation simpler (and consistent with how it worked before)
             // - it would be a non-breaking change to optimize further.
-            renderValue = renderValue
-                .identical(o.literal(true))
-                .conditional(o.literal(''), o.NULL_EXPR);
+            renderValue = renderValue.conditional(o.literal(''), o.NULL_EXPR);
           } else {
             // For attributes other than class convert value to a string.
             // TODO: Skip toString() when we're sure we are binding to a String.

--- a/angular/lib/src/compiler/view_compiler/property_binder.dart
+++ b/angular/lib/src/compiler/view_compiler/property_binder.dart
@@ -229,7 +229,7 @@ void bindAndWriteToRenderer(
 
     var updateStmts = <o.Statement>[];
     switch (boundProp.type) {
-      case PropertyBindingType.Property:
+      case PropertyBindingType.property:
         renderMethod = 'setElementProperty';
         // If user asked for logging bindings, generate code to log them.
         if (boundProp.name == 'className') {
@@ -243,7 +243,7 @@ void bindAndWriteToRenderer(
               [renderNode, o.literal(boundProp.name), renderValue]).toStmt());
         }
         break;
-      case PropertyBindingType.Attribute:
+      case PropertyBindingType.attribute:
         String attrNs;
         String attrName = boundProp.name;
         if (attrName.startsWith('@') && attrName.contains(':')) {
@@ -258,27 +258,43 @@ void bindAndWriteToRenderer(
               .callMethod('updateChildClass', [renderNode, renderValue]);
           updateStmts.add(updateClassExpr.toStmt());
         } else {
-          // For attributes other than class convert value to a string.
-          // TODO: Once we have analyzer summaries and know the type is already
-          // String short-circuit.
-          renderValue =
-              renderValue.callMethod('toString', const [], checked: true);
-
+          if (boundProp.unit == 'if') {
+            // Conditional attribute (i.e. [attr.disabled.if]).
+            //
+            // For now we treat this as a pure transform to make the
+            // implementation simpler (and consistent with how it worked before)
+            // - it would be a non-breaking change to optimize further.
+            renderValue = renderValue
+                .identical(o.literal(true))
+                .conditional(o.literal(''), o.NULL_EXPR);
+          } else {
+            // For attributes other than class convert value to a string.
+            // TODO: Skip toString() when we're sure we are binding to a String.
+            renderValue = renderValue.callMethod(
+              'toString',
+              const [],
+              checked: true,
+            );
+          }
           var params = createSetAttributeParams(
-              renderNode, attrNs, attrName, renderValue);
-
+            renderNode,
+            attrNs,
+            attrName,
+            renderValue,
+          );
           updateStmts.add(new o.InvokeMemberMethodExpr(
-                  attrNs == null ? 'setAttr' : 'setAttrNS', params)
-              .toStmt());
+            attrNs == null ? 'setAttr' : 'setAttrNS',
+            params,
+          ).toStmt());
         }
         break;
-      case PropertyBindingType.Class:
+      case PropertyBindingType.cssClass:
         fieldType = o.BOOL_TYPE;
         renderMethod = isHtmlElement ? 'updateClass' : 'updateElemClass';
         updateStmts.add(new o.InvokeMemberMethodExpr(renderMethod,
             [renderNode, o.literal(boundProp.name), renderValue]).toStmt());
         break;
-      case PropertyBindingType.Style:
+      case PropertyBindingType.style:
         // value = value?.toString().
         o.Expression styleValueExpr =
             currValExpr.callMethod('toString', [], checked: true);


### PR DESCRIPTION
This treats `[attr.name.if]` as a simple transformation. I.e. these two are identical:

```dart
class C {
  @HostBinding('attr.disabed.if')  
  bool isDisabled = false;

  @HostBinding('attr.disabled')
  String get attrDisabled => isDisabled ? '' : null;
}
```

Very excited how simple it was to implement (and the golden looks good too).

While I was here:
* Fixed a relative import deprecation warning in the `_goldens` generator
* Renamed a few enum constants to comply with the Dart style guide

Closes https://github.com/dart-lang/angular/issues/1058