### PR TITLE
don't build the debug entrypoints for tests since there are so many

### DIFF
--- a/_tests/build.debug.yaml
+++ b/_tests/build.debug.yaml
@@ -8,6 +8,8 @@ targets:
           # entrypoints to enable easier debugging.
           - test/**_test.dart
           exclude:
+          - test/**.vm_test.dart
+          - test/**.node_test.dart
           - test/compiler/**
           - test/compiler_integration/**
           - test/source_gen/**

--- a/_tests/build.debug.yaml
+++ b/_tests/build.debug.yaml
@@ -1,0 +1,20 @@
+targets:
+  $default:
+    builders:
+      build_web_compilers|entrypoint:
+        generate_for:
+          include:
+          # Includes both the bootstrapped entrypoints as well as the original
+          # entrypoints to enable easier debugging.
+          - test/**_test.dart
+          exclude:
+          - test/compiler/**
+          - test/compiler_integration/**
+          - test/source_gen/**
+          - test/core/di/provider_test.dart*
+          - test/regression/906_incorrect_injectable_warning_test.dart*
+          - test/regression/519_missing_query_selector_test.dart*
+
+      angular:
+        options:
+          i18n: True

--- a/_tests/build.yaml
+++ b/_tests/build.yaml
@@ -3,6 +3,8 @@ targets:
     builders:
       build_web_compilers|entrypoint:
         generate_for:
+          include:
+          - test/**.browser_test.dart
           exclude:
           - test/compiler/**
           - test/compiler_integration/**


### PR DESCRIPTION
Related to https://github.com/dart-lang/build/issues/1620, this gives far fewer entrypoints to compile - but it does mean that you won't be able to debug tests in the browser using the original test file (you would have to go through --pause-after-load from the test package).

Feel free to close if you don't feel this is desirable.