### PR TITLE
refactor(Compiler): separate unresolved expression handling from type visiting

### DIFF
--- a/_tests/test/compiler_integration/invalid_component_test.dart
+++ b/_tests/test/compiler_integration/invalid_component_test.dart
@@ -3,7 +3,7 @@ import 'package:_tests/compiler.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('should identify a possible unresolvable directive', () async {
+  test('should identify a possibly unresolvable directive', () async {
     await compilesExpecting('''
       import '$ngImport';
 
@@ -19,6 +19,23 @@ void main() {
           ValidDirective,
         ],
         template: '',
+      )
+      class BadComp {}
+    ''', errors: [
+      allOf([
+        contains('Compiling @Component-annotated class "BadComp" failed'),
+      ]),
+    ]);
+  });
+
+  test('should identify a possibly unresolvable pipe', () async {
+    await compilesExpecting('''
+      import '$ngImport';
+
+      @Component(
+        selector: 'bad-comp',
+        template: '',
+        pipes: [MissingPipe],
       )
       class BadComp {}
     ''', errors: [

--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Bug fixes
+
+*   Fails the build immediately if an element in a component's `pipes` list is
+    unresolved.
+
 ## 5.0.0-beta
 
 Welcome to the first release candidate of AngularDart v5.0.0, with full support

--- a/angular/lib/src/source_gen/template_compiler/dart_object_utils.dart
+++ b/angular/lib/src/source_gen/template_compiler/dart_object_utils.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element.dart';
 
 /// Reads and returns [field] on [value] as a boolean.
 ///
@@ -96,6 +97,16 @@ T coerceEnum<T>(
     );
   }
   return enumValue;
+}
+
+/// Returns the element representing the declaration of [value]'s type.
+///
+/// May return null if [value] isn't a valid constant expression or has an
+/// unknown type.
+Element elementOf(DartObject value) {
+  // For functions, `toTypeValue()` is null so we fall back on `type`.
+  final type = value.toTypeValue() ?? value.type;
+  return type?.element;
 }
 
 // TODO: For whatever reason 'ByName' works in Bazel, but not 'ByIndex', and the

--- a/angular/lib/src/source_gen/template_compiler/find_components.dart
+++ b/angular/lib/src/source_gen/template_compiler/find_components.dart
@@ -27,7 +27,6 @@ import 'compile_metadata.dart';
 import 'dart_object_utils.dart';
 import 'pipe_visitor.dart';
 
-const String _directivesProperty = 'directives';
 const String _visibilityProperty = 'visibility';
 const _statefulDirectiveFields = const [
   'exportAs',
@@ -75,64 +74,36 @@ class _NormalizedComponentVisitor extends RecursiveElementVisitor<Null> {
     return null;
   }
 
-  List<CompilePipeMetadata> _visitPipes(ClassElement element) => _visitTypes(
-        element,
-        'pipes',
-        () => new PipeVisitor(_library),
-      );
+  List<CompilePipeMetadata> _visitPipes(ClassElement element) =>
+      _visitTypes(element, 'pipes', () => new PipeVisitor(_library));
 
   List<CompileDirectiveMetadata> _visitDirectives(ClassElement element) =>
-      _visitTypes(
-        element,
-        _directivesProperty,
-        () => new _ComponentVisitor(_library),
-      );
+      _visitTypes(element, 'directives', () => new _ComponentVisitor(_library));
 
   List<T> _visitTypes<T>(
     ClassElement element,
     String field,
     ElementVisitor<T> visitor(),
   ) {
-    return element.metadata
-        .where(safeMatcher(isComponent))
-        .expand((annotation) => _visitTypesForComponent(
-              coerceList(annotation.computeConstantValue(), field),
-              visitor,
-              // Only pass the annotation for directives: [ ... ], not other
-              // elements. They also can cause problems if not resolved but it
-              // is missing directives that blow up in a non-actionable way.
-              annotation: field == _directivesProperty
-                  ? annotation as ElementAnnotationImpl
-                  : null,
-              element: element,
-            ))
-        .toList();
-  }
-
-  List<T> _visitTypesForComponent<T>(
-    Iterable<DartObject> directives,
-    ElementVisitor<T> visitor(), {
-    ElementAnnotationImpl annotation,
-    ClassElement element,
-  }) {
-    // TODO(matanl): Extract this code somewhere common, likely useful.
-    if (directives.isEmpty && annotation != null) {
+    final annotation = element.metadata.firstWhere(safeMatcher(isComponent));
+    final values = coerceList(annotation.computeConstantValue(), field);
+    if (values.isEmpty) {
       // Two reasons we got to this point:
-      // 1. The directives: const [ ... ] list was empty or omitted.
+      // 1. The list argument was empty or omitted.
       // 2. One or more identifiers in the list were not resolved, potentially
       //    due to missing imports or dependencies.
       //
       // The latter is specifically tricky to debug, because it ends up failing
       // template parsing in a similar way to #1, but a user will look at the
       // code and not see a problem potentially.
-      for (final argument in annotation.annotationAst.arguments.arguments) {
-        if (argument is NamedExpression &&
-            argument.name.label.name == _directivesProperty) {
+      final annotationImpl = annotation as ElementAnnotationImpl;
+      for (final argument in annotationImpl.annotationAst.arguments.arguments) {
+        if (argument is NamedExpression && argument.name.label.name == field) {
           final values = argument.expression as ListLiteral;
           if (values.elements.isNotEmpty &&
-              // Avoid an edge case where all of your directives: ... entries
-              // are just empty lists. Not likely to happen, but might as well
-              // check anyway at this point.
+              // Avoid an edge case where all of your entries are just empty
+              // lists. Not likely to happen, but might as well check anyway at
+              // this point.
               values.elements.every((e) => e.staticType?.isDynamic != false)) {
             // We didn't resolve something.
             _failFastOnUnresolvedExpressions(
@@ -142,9 +113,9 @@ class _NormalizedComponentVisitor extends RecursiveElementVisitor<Null> {
         }
       }
     }
-    return visitAll<T>(directives, (obj) {
+    return visitAll(values, (value) {
       // For functions, `toTypeValue()` is null so we fall back on `type`.
-      final type = obj.toTypeValue() ?? obj.type;
+      final type = value.toTypeValue() ?? value.type;
       return type?.element?.accept(visitor());
     });
   }

--- a/angular/lib/src/source_gen/template_compiler/find_components.dart
+++ b/angular/lib/src/source_gen/template_compiler/find_components.dart
@@ -74,16 +74,30 @@ class _NormalizedComponentVisitor extends RecursiveElementVisitor<Null> {
     return null;
   }
 
-  List<CompilePipeMetadata> _visitPipes(ClassElement element) =>
-      _visitTypes(element, 'pipes', () => new PipeVisitor(_library));
+  List<CompileDirectiveMetadata> _visitDirectives(ClassElement element) {
+    final values = _getResolvedArgumentsOrFail(element, 'directives');
+    return visitAll(values, (value) {
+      return elementOf(value)?.accept(_ComponentVisitor(_library));
+    });
+  }
 
-  List<CompileDirectiveMetadata> _visitDirectives(ClassElement element) =>
-      _visitTypes(element, 'directives', () => new _ComponentVisitor(_library));
+  List<CompilePipeMetadata> _visitPipes(ClassElement element) {
+    final values = _getResolvedArgumentsOrFail(element, 'pipes');
+    return visitAll(values, (value) {
+      return elementOf(value)?.accept(PipeVisitor(_library));
+    });
+  }
 
-  List<T> _visitTypes<T>(
+  /// Returns the arguments assigned to [field], ensuring they're resolved.
+  ///
+  /// This will immediately fail compilation and inform the user if any
+  /// arguments can't be resolved. Failing here avoids misleading errors that
+  /// arise from unresolved arguments later on in compilation.
+  ///
+  /// This assumes [field] expects a list of arguments.
+  List<DartObject> _getResolvedArgumentsOrFail(
     ClassElement element,
     String field,
-    ElementVisitor<T> visitor(),
   ) {
     final annotation = element.metadata.firstWhere(safeMatcher(isComponent));
     final values = coerceList(annotation.computeConstantValue(), field);
@@ -113,11 +127,7 @@ class _NormalizedComponentVisitor extends RecursiveElementVisitor<Null> {
         }
       }
     }
-    return visitAll(values, (value) {
-      // For functions, `toTypeValue()` is null so we fall back on `type`.
-      final type = value.toTypeValue() ?? value.type;
-      return type?.element?.accept(visitor());
-    });
+    return values;
   }
 }
 


### PR DESCRIPTION
This is needed for an upcoming change that requires the former without the
latter.