### PR TITLE
fix(Perf): Fix double-invoke of 'mapNestedViews'.

### DIFF
--- a/_goldens/test/_files/queries.dart
+++ b/_goldens/test/_files/queries.dart
@@ -41,6 +41,9 @@ class QueriesComponent {
 
   @ViewChildren(AnotherDirective)
   List<AnotherDirective> usingTypeFromField;
+
+  @ViewChild('q3')
+  AnotherDirective nestedViewChild;
 }
 
 @Component(

--- a/_goldens/test/_files/queries.template.golden
+++ b/_goldens/test/_files/queries.template.golden
@@ -33,6 +33,7 @@ class ViewQueriesComponent0 extends AppView<import1.QueriesComponent> {
   bool _query_q2_1_3_isDirty = true;
   bool _query_q2_1_4_isDirty = true;
   bool _query_AnotherDirective_1_5_isDirty = true;
+  bool _query_q3_1_6_isDirty = true;
   import2.Element _el_0;
   import1.AnotherDirective _AnotherDirective_0_5;
   import2.Element _el_1;
@@ -85,6 +86,12 @@ class ViewQueriesComponent0 extends AppView<import1.QueriesComponent> {
         ]);
         _query_AnotherDirective_1_5_isDirty = false;
       }
+      if (_query_q3_1_6_isDirty) {
+        ctx.nestedViewChild = import8.firstOrNull(_appEl_2.mapNestedViews((_ViewQueriesComponent1 nestedView) {
+          return [new ElementRef(nestedView._el_0)];
+        }));
+        _query_q3_1_6_isDirty = false;
+      }
     }
   }
 
@@ -116,6 +123,7 @@ class _ViewQueriesComponent1 extends AppView<import1.QueriesComponent> {
   @override
   void dirtyParentQueriesInternal() {
     (parentView as ViewQueriesComponent0)._query_AnotherDirective_1_5_isDirty = true;
+    (parentView as ViewQueriesComponent0)._query_q3_1_6_isDirty = true;
   }
 }
 

--- a/_goldens/tool/update.dart
+++ b/_goldens/tool/update.dart
@@ -11,7 +11,7 @@ import 'package:path/path.dart' as p;
 ///
 /// Then:
 /// ```
-/// dart tool/goldens.dart
+/// dart tool/update.dart
 /// ```
 void main() {
   final output = p.join(p.current, 'test', '_files');

--- a/angular/lib/src/compiler/identifiers.dart
+++ b/angular/lib/src/compiler/identifiers.dart
@@ -130,6 +130,8 @@ class Identifiers {
       name: 'createTrustedHtml', moduleUrl: appViewUtilsModuleUrl);
   static final flattenNodes = new CompileIdentifierMetadata<dynamic>(
       name: "flattenNodes", moduleUrl: appViewUtilsModuleUrl);
+    static final firstOrNull = new CompileIdentifierMetadata<dynamic>(
+      name: "firstOrNull", moduleUrl: appViewUtilsModuleUrl);
   static final EMPTY_ARRAY = new CompileIdentifierMetadata<dynamic>(
       name: "EMPTY_ARRAY", moduleUrl: appViewUtilsModuleUrl);
   static final EMPTY_MAP = new CompileIdentifierMetadata<dynamic>(

--- a/angular/lib/src/core/linker/app_view_utils.dart
+++ b/angular/lib/src/core/linker/app_view_utils.dart
@@ -95,6 +95,9 @@ List<T> flattenNodes<T>(List<List<T>> nodes) {
   return result;
 }
 
+/// Returns the first item of [items], or `null` if the list is empty.
+T firstOrNull<T>(List<T> items) => items.isNotEmpty ? items.first: null;
+
 dynamic interpolate0(dynamic p) {
   if (p is String) return p;
   if (p is SafeValue) return p;


### PR DESCRIPTION
Closes https://github.com/dart-lang/angular/issues/1455

**BEFORE**:
```dart
if (_query_foo_1_0_isDirty) {
    ctx.foo = (_appEl_0.mapNestedViews((_ViewAppComponent1 nestedView) {
      return [nestedView._el_2];
    }).isNotEmpty
        ? _appEl_0.mapNestedViews((_ViewAppComponent1 nestedView) {
            return [nestedView._el_2];
          }).first
        : null);
    _query_foo_1_0_isDirty = false;
  }
```

**AFTER**:
```dart
if (_query_foo_1_0_isDirty) {
  ctx.foo = import8.firstOrNull(_appEl_0.mapNestedViews((_ViewAppComponent1 nestedView) {
    return [nestedView._el_2];
  });
  _query_foo_1_0_isDirty = false;
}
```

(This was _significantly_ easier than making a local variable, and effectively does the same thing)