### PR TITLE
feat(Perf): Optimize dirtyParentQueriesInternal.

### DIFF
--- a/_goldens/test/_files/queries.template.golden
+++ b/_goldens/test/_files/queries.template.golden
@@ -115,7 +115,7 @@ class _ViewQueriesComponent1 extends AppView<import1.QueriesComponent> {
 
   @override
   void dirtyParentQueriesInternal() {
-    (parentView as ViewQueriesComponent0)._query_AnotherDirective_1_5_isDirty = true;
+    import9.unsafeCast<ViewQueriesComponent0>(parentView)._query_AnotherDirective_1_5_isDirty = true;
   }
 }
 
@@ -235,7 +235,7 @@ class _ViewEmbeddedQueries1 extends AppView<import1.EmbeddedQueries> {
 
   @override
   void dirtyParentQueriesInternal() {
-    (parentView as ViewEmbeddedQueries0)._query_AnotherDirective_1_0_isDirty = true;
+    import9.unsafeCast<ViewEmbeddedQueries0>(parentView)._query_AnotherDirective_1_0_isDirty = true;
   }
 }
 
@@ -260,7 +260,7 @@ class _ViewEmbeddedQueries2 extends AppView<import1.EmbeddedQueries> {
 
   @override
   void dirtyParentQueriesInternal() {
-    (parentView as ViewEmbeddedQueries0)._query_AnotherDirective_1_0_isDirty = true;
+    import9.unsafeCast<ViewEmbeddedQueries0>(parentView)._query_AnotherDirective_1_0_isDirty = true;
   }
 }
 
@@ -377,7 +377,7 @@ class _ViewEmbeddedQueriesList1 extends AppView<import1.EmbeddedQueriesList> {
 
   @override
   void dirtyParentQueriesInternal() {
-    (parentView as ViewEmbeddedQueriesList0)._query_AnotherDirective_1_0_isDirty = true;
+    import9.unsafeCast<ViewEmbeddedQueriesList0>(parentView)._query_AnotherDirective_1_0_isDirty = true;
   }
 }
 
@@ -402,7 +402,7 @@ class _ViewEmbeddedQueriesList2 extends AppView<import1.EmbeddedQueriesList> {
 
   @override
   void dirtyParentQueriesInternal() {
-    (parentView as ViewEmbeddedQueriesList0)._query_AnotherDirective_1_0_isDirty = true;
+    import9.unsafeCast<ViewEmbeddedQueriesList0>(parentView)._query_AnotherDirective_1_0_isDirty = true;
   }
 }
 
@@ -601,7 +601,7 @@ class _ViewNestedNgForQueriesList3 extends AppView<import1.NestedNgForQueriesLis
 
   @override
   void dirtyParentQueriesInternal() {
-    (parentView.parentView.parentView as ViewNestedNgForQueriesList0)._query_taggedItem_1_0_isDirty = true;
+    import9.unsafeCast<ViewNestedNgForQueriesList0>(parentView.parentView.parentView)._query_taggedItem_1_0_isDirty = true;
   }
 }
 

--- a/angular/lib/src/compiler/identifiers.dart
+++ b/angular/lib/src/compiler/identifiers.dart
@@ -104,6 +104,9 @@ class Identifiers {
       name: "AppViewUtils.throwOnChanges", moduleUrl: appViewUtilsModuleUrl);
   static final isDevMode = new CompileIdentifierMetadata<dynamic>(
       name: "isDevMode", moduleUrl: runtimeUtilsModuleUrl);
+  static final unsafeCast = new CompileIdentifierMetadata<dynamic>(
+      name: "unsafeCast", moduleUrl: runtimeUtilsModuleUrl);
+
   static final interpolate = <CompileIdentifierMetadata>[
     new CompileIdentifierMetadata<dynamic>(
         name: "interpolate0", moduleUrl: appViewUtilsModuleUrl),

--- a/angular/lib/src/compiler/output/abstract_emitter.dart
+++ b/angular/lib/src/compiler/output/abstract_emitter.dart
@@ -331,15 +331,6 @@ abstract class AbstractEmitterVisitor
   String getBuiltinMethodName(o.BuiltinMethod method);
 
   @override
-  void visitInvokeFunctionExpr(
-      o.InvokeFunctionExpr expr, EmitterVisitorContext context) {
-    expr.fn.visitExpression(this, context);
-    context.print('(');
-    visitAllExpressions(expr.args, context, ',');
-    context.print(')');
-  }
-
-  @override
   void visitReadVarExpr(o.ReadVarExpr ast, EmitterVisitorContext context) {
     var varName = ast.name;
     if (ast.builtin != null) {

--- a/angular/lib/src/compiler/output/dart_emitter.dart
+++ b/angular/lib/src/compiler/output/dart_emitter.dart
@@ -406,6 +406,28 @@ class _DartEmitterVisitor extends AbstractEmitterVisitor
   }
 
   @override
+  void visitInvokeFunctionExpr(
+    o.InvokeFunctionExpr expr,
+    EmitterVisitorContext context,
+  ) {
+    expr.fn.visitExpression(this, context);
+    var types = expr.typeArgs;
+    if (types != null) {
+      context.print('<');
+      for (var i = 0; i < types.length; i++) {
+        types[i].visitType(this, context);
+        if (i < types.length - 1) {
+          context.print(', ');
+        }
+      }
+      context.print('>');
+    }
+    context.print('(');
+    visitAllExpressions(expr.args, context, ',');
+    context.print(')');
+  }
+
+  @override
   void visitInstantiateExpr(
       o.InstantiateExpr ast, EmitterVisitorContext context) {
     context.print(_isConstType(ast.type) ? 'const' : 'new');

--- a/angular/lib/src/compiler/output/output_ast.dart
+++ b/angular/lib/src/compiler/output/output_ast.dart
@@ -137,8 +137,11 @@ abstract class Expression {
     return new InvokeMethodExpr(this, name, params, checked: checked);
   }
 
-  InvokeFunctionExpr callFn(List<Expression> params) {
-    return new InvokeFunctionExpr(this, params);
+  InvokeFunctionExpr callFn(
+    List<Expression> params, [
+    List<OutputType> typeArguments,
+  ]) {
+    return new InvokeFunctionExpr(this, params, typeArguments);
   }
 
   InstantiateExpr instantiate(
@@ -427,7 +430,9 @@ class InvokeMemberMethodExpr extends Expression {
 class InvokeFunctionExpr extends Expression {
   final Expression fn;
   final List<Expression> args;
-  InvokeFunctionExpr(this.fn, this.args, [OutputType type]) : super(type);
+  final List<OutputType> typeArgs;
+
+  InvokeFunctionExpr(this.fn, this.args, this.typeArgs, [OutputType type]) : super(type);
 
   @override
   R visitExpression<R, C>(ExpressionVisitor<R, C> visitor, C context) {
@@ -976,7 +981,7 @@ class _ExpressionTransformer<C>
   @override
   Expression visitInvokeFunctionExpr(InvokeFunctionExpr ast, C context) {
     return new InvokeFunctionExpr(ast.fn.visitExpression(this, context),
-        this.visitAllExpressions(ast.args, context), ast.type);
+        this.visitAllExpressions(ast.args, context), [], ast.type);
   }
 
   @override

--- a/angular/lib/src/compiler/view_compiler/view_compiler_utils.dart
+++ b/angular/lib/src/compiler/view_compiler/view_compiler_utils.dart
@@ -39,9 +39,19 @@ List<o.Expression> createSetAttributeParams(o.Expression renderNode,
   }
 }
 
+final _unsafeCastFn = o.importExpr(Identifiers.unsafeCast);
+
+/// Returns `unsafeCast<{Cast}>(expression)`.
+o.Expression _unsafeCast(o.Expression expression, [o.OutputType cast]) {
+  return _unsafeCastFn.callFn([expression], cast != null ? [cast] : const []);
+}
+
 o.Expression getPropertyInView(
-    o.Expression property, CompileView callingView, CompileView definedView,
-    {bool forceCast = false}) {
+  o.Expression property,
+  CompileView callingView,
+  CompileView definedView, {
+  bool forceCast = false,
+}) {
   if (identical(callingView, definedView)) {
     return property;
   } else {
@@ -67,10 +77,10 @@ o.Expression getPropertyInView(
               .any((field) => field.name == readMemberExpr.name) ||
           definedView.getters
               .any((field) => field.name == readMemberExpr.name)) {
-        viewProp = viewProp.cast(definedView.classType);
+        viewProp = _unsafeCast(viewProp, definedView.classType);
       }
     } else if (forceCast) {
-      viewProp = viewProp.cast(definedView.classType);
+      viewProp = _unsafeCast(viewProp, definedView.classType);
     }
     return o.replaceReadClassMemberInExpression(viewProp, property);
   }


### PR DESCRIPTION
Replaces `p as ViewQueriesComponent0` with `unsafeCast<ViewQueriesComponent0>(p)`.

In Dart2JS with `--omit-implicit-checks` this is of code-size and runtime benefit. Ideally we would find a better way to properly type `.parentView` (either with an `AppView` refactor with more proper generics, or another approach), but this at least does a bit for us now.