### PR TITLE
chore(Misc): Cleanup analysis_options, naming.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,4 @@
 analyzer:
-  strong-mode: true
   errors:
     unused_element: error
     unused_import: error
@@ -12,8 +11,8 @@ analyzer:
     # The noise of deprecations isn't worth the effort.
     deprecated_member_use: ignore
   exclude:
-    - .dart_tool/**
-    - build/**
+    - "*/.dart_tool/**"
+    - "*/build/**"
 
 linter:
   rules:

--- a/angular_test/test/frontend/bed_static_test.dart
+++ b/angular_test/test/frontend/bed_static_test.dart
@@ -3,14 +3,14 @@ import 'package:test/test.dart';
 import 'package:angular/angular.dart';
 import 'package:angular_test/angular_test.dart';
 
-import 'bed_static_test.template.dart' as ng_generated;
+import 'bed_static_test.template.dart' as ng;
 
 void main() {
   // Intentional explicit lack of ng_generated.initReflector().
 
   test('should create a component with a ComponentFactory', () async {
     final testBed = NgTestBed.forComponent<ExampleComp>(
-      ng_generated.ExampleCompNgFactory,
+      ng.ExampleCompNgFactory,
       rootInjector: mathInjector,
     );
     final fixture = await testBed.create();
@@ -25,7 +25,7 @@ void main() {
 @GenerateInjector(const [
   const Provider(MathService),
 ])
-final InjectorFactory mathInjector = ng_generated.mathInjector$Injector;
+final InjectorFactory mathInjector = ng.mathInjector$Injector;
 
 class MathService {
   num add(num a, num b) => a + b;


### PR DESCRIPTION
... remove `strong-mode: ...` which is deprecated, and `ng_generated` -> `ng`.