### PR TITLE
fix(Perf): Collapse [most] `if (firstChecked) { ... }`.

### DIFF
--- a/_goldens/test/_files/core_directives.template.golden
+++ b/_goldens/test/_files/core_directives.template.golden
@@ -65,8 +65,6 @@ class ViewTestFooComponent0 extends AppView<import1.TestFooComponent> {
           addInlinedNodes(_anchor_0, [_el_0_0], true);
         }
       }
-    }
-    if (firstCheck) {
       if (!identical(_ctx.bars, null)) {
         (_NgFor_1_9.ngForOf = _ctx.bars);
       }

--- a/_goldens/test/_files/empty_properties.template.golden
+++ b/_goldens/test/_files/empty_properties.template.golden
@@ -72,16 +72,10 @@ class ViewEmptyPropertiesComponent0 extends AppView<import1.EmptyPropertiesCompo
   void detectChangesInternal() {
     bool firstCheck = (this.cdState == 0);
     if (firstCheck) {
-      (_FancyButtonComponent_0_5.raised = true);
-    }
-    if (firstCheck) {
-      (_FancyButtonComponent_1_5.raised = true);
-    }
-    if (firstCheck) {
-      (_FancyButtonComponent_2_5.raised = true);
-    }
-    if (firstCheck) {
-      (_FancyButtonComponent_3_5.raised = false);
+      _FancyButtonComponent_0_5.raised = true;
+      _FancyButtonComponent_1_5.raised = true;
+      _FancyButtonComponent_2_5.raised = true;
+      _FancyButtonComponent_3_5.raised = false;
     }
     _compView_0.detectChanges();
     _compView_1.detectChanges();

--- a/angular/lib/src/compiler/view_compiler/compile_method.dart
+++ b/angular/lib/src/compiler/view_compiler/compile_method.dart
@@ -1,16 +1,16 @@
-import "../output/output_ast.dart" as o;
+import '../output/output_ast.dart' as o;
+
+import 'constants.dart';
 
 /// Creates a list of statements for a method body that include debug context.
 ///
-/// Use resetDebugInfo to provide an anchor to the ast node for which we are
-/// about to generate code for.
-///
 /// Use addStmt/addStmts to add statements at the current checkpoint.
 class CompileMethod {
+  static final _isFirstCheckIfBlock = new Expando<bool>();
   final _bodyStatements = <o.Statement>[];
-  final bool genDebugInfo;
 
-  CompileMethod(this.genDebugInfo);
+  // TODO: Remove this parameter, it is a no-op.
+  CompileMethod(@deprecated bool genDebugInfo);
 
   void addStmt(o.Statement stmt) {
     _bodyStatements.add(stmt);
@@ -19,6 +19,24 @@ class CompileMethod {
   void addStmts(List<o.Statement> stmts) {
     if (stmts.isEmpty) return;
     _bodyStatements.addAll(stmts);
+  }
+
+  /// If the last added statement is an `if (firstCheck)`, re-use that if-block.
+  ///
+  /// Otherwise, creates a new if-block and inserts it.
+  void addStmtsIfFirstCheck(List<o.Statement> stmts) {
+    // This is not the cleanest solution (i.e. it pollutes this class), but
+    // otherwise you would need similar code in 10+ places.
+    //
+    // https://github.com/dart-lang/angular/issues/712#issuecomment-403189258
+    final lastStmt = _bodyStatements.isNotEmpty ? _bodyStatements.last : null;
+    if (lastStmt is o.IfStmt && _isFirstCheckIfBlock[lastStmt] == true) {
+      lastStmt.trueCase.addAll(stmts);
+    } else {
+      final ifStmt = new o.IfStmt(DetectChangesVars.firstCheck, stmts);
+      _isFirstCheckIfBlock[ifStmt] = true;
+      addStmt(ifStmt);
+    }
   }
 
   /// Returns set of variable reads in method.

--- a/angular/lib/src/compiler/view_compiler/lifecycle_binder.dart
+++ b/angular/lib/src/compiler/view_compiler/lifecycle_binder.dart
@@ -37,6 +37,8 @@ void bindDirectiveDetectChangesLifecycleCallbacks(DirectiveAst directiveAst,
     }
   }
   if (lifecycleHooks.contains(LifecycleHooks.onInit)) {
+    // We don't re-use the existing IfStmt (.addStmtsIfFirstCheck), because we
+    // require an additional condition (`notThrowOnChanges`).
     detectChangesInInputsMethod.addStmt(new o.IfStmt(
         notThrowOnChanges.and(DetectChangesVars.firstCheck),
         [directiveInstance.callMethod('ngOnInit', []).toStmt()]));
@@ -56,9 +58,9 @@ void bindDirectiveAfterContentLifecycleCallbacks(
   var afterContentLifecycleCallbacksMethod =
       view.afterContentLifecycleCallbacksMethod;
   if (!identical(lifecycleHooks.indexOf(LifecycleHooks.afterContentInit), -1)) {
-    afterContentLifecycleCallbacksMethod.addStmt(new o.IfStmt(
-        DetectChangesVars.firstCheck,
-        [directiveInstance.callMethod('ngAfterContentInit', []).toStmt()]));
+    afterContentLifecycleCallbacksMethod.addStmtsIfFirstCheck([
+      directiveInstance.callMethod('ngAfterContentInit', []).toStmt(),
+    ]);
   }
   if (!identical(
       lifecycleHooks.indexOf(LifecycleHooks.afterContentChecked), -1)) {
@@ -76,9 +78,9 @@ void bindDirectiveAfterViewLifecycleCallbacks(
   var afterViewLifecycleCallbacksMethod =
       view.afterViewLifecycleCallbacksMethod;
   if (!identical(lifecycleHooks.indexOf(LifecycleHooks.afterViewInit), -1)) {
-    afterViewLifecycleCallbacksMethod.addStmt(new o.IfStmt(
-        DetectChangesVars.firstCheck,
-        [directiveInstance.callMethod('ngAfterViewInit', []).toStmt()]));
+    afterViewLifecycleCallbacksMethod.addStmtsIfFirstCheck([
+      directiveInstance.callMethod('ngAfterViewInit', []).toStmt(),
+    ]);
   }
   if (!identical(lifecycleHooks.indexOf(LifecycleHooks.afterViewChecked), -1)) {
     afterViewLifecycleCallbacksMethod.addStmt(

--- a/angular/lib/src/compiler/view_compiler/property_binder.dart
+++ b/angular/lib/src/compiler/view_compiler/property_binder.dart
@@ -179,8 +179,9 @@ void bindRenderText(
       constantRenderMethod,
       view.genDebugInfo);
   if (constantRenderMethod.isNotEmpty) {
-    view.detectChangesRenderPropertiesMethod.addStmt(new o.IfStmt(
-        DetectChangesVars.firstCheck, constantRenderMethod.finish()));
+    view.detectChangesRenderPropertiesMethod.addStmtsIfFirstCheck(
+      constantRenderMethod.finish(),
+    );
   }
   if (dynamicRenderMethod.isNotEmpty) {
     view.detectChangesRenderPropertiesMethod
@@ -325,8 +326,7 @@ void bindAndWriteToRenderer(
         isHostComponent: isHostComponent);
   }
   if (constantPropertiesMethod.isNotEmpty) {
-    targetMethod.addStmt(new o.IfStmt(
-        DetectChangesVars.firstCheck, constantPropertiesMethod.finish()));
+    targetMethod.addStmtsIfFirstCheck(constantPropertiesMethod.finish());
   }
   if (dynamicPropertiesMethod.isNotEmpty) {
     targetMethod.addStmts(dynamicPropertiesMethod.finish());
@@ -573,8 +573,9 @@ void bindDirectiveInputs(DirectiveAst directiveAst,
     }
   }
   if (constantInputsMethod.isNotEmpty) {
-    detectChangesInInputsMethod.addStmt(new o.IfStmt(
-        DetectChangesVars.firstCheck, constantInputsMethod.finish()));
+    detectChangesInInputsMethod.addStmtsIfFirstCheck(
+      constantInputsMethod.finish(),
+    );
   }
   if (dynamicInputsMethod.isNotEmpty) {
     detectChangesInInputsMethod.addStmts(dynamicInputsMethod.finish());
@@ -699,8 +700,9 @@ void bindInlinedNgIf(DirectiveAst directiveAst, CompileElement compileElement) {
       fieldExprInitializer: o.literal(false));
 
   if (constantInputsMethod.isNotEmpty) {
-    detectChangesInInputsMethod.addStmt(new o.IfStmt(
-        DetectChangesVars.firstCheck, constantInputsMethod.finish()));
+    detectChangesInInputsMethod.addStmtsIfFirstCheck(
+      constantInputsMethod.finish(),
+    );
   }
   if (dynamicInputsMethod.isNotEmpty) {
     detectChangesInInputsMethod.addStmts(dynamicInputsMethod.finish());


### PR DESCRIPTION
Closes https://github.com/dart-lang/angular/issues/712.

The solution is a bit hacky, but probably better than making `CompileMethod` a super public structure where code branches look _into_ the existing body statements, at least this maintains the API for the most part.

I see two improvements in the goldens, but I am not sure how it affects "real" apps.