### PR TITLE
Fix doc link anchors

### DIFF
--- a/doc/effective/change-detection.md
+++ b/doc/effective/change-detection.md
@@ -32,7 +32,7 @@ templates that maximize the performance of your app.
     *   [PREFER `ngAfterChanges` to
         `ngOnChanges`](#prefer-implementing-afterchanges-to-onchanges)
     *   [PREFER setters to
-        `ngAfterXChecked`](#prefer-settings-to-ngafterxchecked)
+        `ngAfterXChecked`](#prefer-setters-to-ngafterxchecked)
     *   [PREFER `bool` setters to using
         `getBool`](#prefer-bool-setters-to-using-getbool)
     *   [PREFER using `OnPush` where
@@ -42,7 +42,7 @@ templates that maximize the performance of your app.
 
 ### AVOID expensive bindings
 
-Change detection is run on every tick for every component in the app. One 
+Change detection is run on every tick for every component in the app. One
 expensive template binding can bring the entire app to a crawl. Performing
 expensive computations in your template bindings is always a bad idea.
 
@@ -283,8 +283,8 @@ class MyComponent implements DoCheck {
   @Input()
   List<String> names;
   String _firstName;
-  bool _firstNameUpdated = false; 
-  
+  bool _firstNameUpdated = false;
+
   @override
   void ngDoCheck() {
     _firstNameUpdated = _firstName == names.first;

--- a/doc/effective/di.md
+++ b/doc/effective/di.md
@@ -17,7 +17,7 @@ guide is meant to serve as a **development tool** and to help push **best
 practices** from the developers of the AngularDart framework.
 
 *   [Providers](#providers)
-    *   [DO use the "named" providers](#do-use-the-named-providers)
+    *   [DO use the "named" providers](#do-use-named-providers)
     *   [DO use factories for
         configuration](#do-use-factories-for-configuration)
     *   [AVOID `ValueProvider` for complex
@@ -44,7 +44,7 @@ practices** from the developers of the AngularDart framework.
 
 ## Providers
 
-### DO use the "named" providers
+### DO use "named" providers
 
 While not formally deprecated, `provide(...)` and `Provider(...)` require
 certain combinations of named optional parameters, and allow combinations that
@@ -206,8 +206,8 @@ void main() {
 
 ### DO use the `.forToken` constructor for tokens
 
-In alignment with [DO use typed `OpaqueToken<T>`](#...) and [DO use the "named"
-providers](#...), the `.forToken` constructor should be used in order for type
+In alignment with [DO use typed `OpaqueToken<T>`](#do-use-typed-opaquetokent) and
+[DO use "named" providers](#do-use-named-providers), the `.forToken` constructor should be used in order for type
 inference to determine the type of the provider.
 
 **BAD**:

--- a/doc/faq/component-loading.md
+++ b/doc/faq/component-loading.md
@@ -58,7 +58,7 @@ void doSomething() {
 
 It's always the class _name_ with a suffix of `NgFactory`.
 
-See [migration](#Migration) below for how to migrate off using a `Type`.
+See [migration](#migration) below for how to migrate off using a `Type`.
 
 ## Overview
 
@@ -223,7 +223,7 @@ void ngOnInit() async {
     await example_1.loadLibrary();
     example_1.initReflector();
     component = example_1.Example1ComponentNgFactory;
-  } 
+  }
 }
 ```
 


### PR DESCRIPTION
This PR fixes the link anchors, and tweaks a title.

The broken anchors were reported [here](https://github.com/dart-lang/site-webdev/pull/1697#issuecomment-404215607):

```nocode
http://localhost:4001/angular/note/effective/change-detection
- (367:10) 'PREFER s..' => http://localhost:4001/angular/note/effective/change-detection#prefer-settings-to-ngafterxchecked (HTTP 200 but missing anchor)
http://localhost:4001/angular/note/effective/di
- (568:21) 'DO use t..' => http://localhost:4001/angular/note/effective/di#... (HTTP 200 but missing anchor)
- (568:117) 'DO use t..' => http://localhost:4001/angular/note/effective/di#... (HTTP 200 but missing anchor)
http://localhost:4001/angular/note/faq/component-loading
- (379:7) 'migration' => http://localhost:4001/angular/note/faq/component-loading#Migration (HTTP 200 but missing anchor)
http://localhost:4001/angular/note/faq/di
- (552:42) 'dependen..' => http://localhost:4001/angular/note/effective/di.md#components (HTTP 404)
```

cc @kwalrath @kevmoo 