### PR TITLE
fix(angular_forms): Fix Pattern Validator not accepting dynamic values

### DIFF
--- a/angular_forms/lib/src/directives/validators.dart
+++ b/angular_forms/lib/src/directives/validators.dart
@@ -172,11 +172,10 @@ class MaxLengthValidator implements Validator {
   ],
 )
 class PatternValidator implements Validator {
-  final ValidatorFn _validator;
-
-  PatternValidator(@Attribute('pattern') String pattern)
-      : _validator = Validators.pattern(pattern);
+  @HostBinding('attr.pattern')
+  @Input()
+  String pattern;
 
   @override
-  Map<String, dynamic> validate(AbstractControl c) => _validator(c);
+  Map<String, dynamic> validate(AbstractControl c) => Validators.pattern(pattern)(c);
 }

--- a/angular_forms/test/validator_directives_test.dart
+++ b/angular_forms/test/validator_directives_test.dart
@@ -67,7 +67,7 @@ void main() {
 
     tearDown(() => disposeAnyRunningTest());
 
-    Future<void> updateRequired({String pattern}) async {
+    Future<void> updatePattern({String pattern}) async {
       await fixture.update((cmp) => cmp.pattern = pattern);
       // We have to do this in a separate turn, so that new required value has
       // propagated.
@@ -81,15 +81,23 @@ void main() {
     test('can be triggered dynamically', () async {
       expect(dynamicControlValid(), true);
 
-      await updateRequired(pattern: '[A-Za-z]*');
+      await updatePattern(pattern: '[A-Za-z]*');
 
       expect(dynamicControlValid(), true);
+
+      await fixture.update((cmp) => cmp.value = '123');
+
+      expect(dynamicControlValid(), false);
 
       await fixture.update((cmp) => cmp.value = 'abc');
 
       expect(dynamicControlValid(), true);
 
-      await updateRequired(pattern: '[a-z]*');
+      await updatePattern(pattern: '[1-9]*');
+
+      expect(dynamicControlValid(), false);
+
+      await updatePattern(pattern: '[a-z]*');
 
       expect(dynamicControlValid(), true);
 

--- a/angular_forms/test/validator_directives_test.dart
+++ b/angular_forms/test/validator_directives_test.dart
@@ -55,6 +55,53 @@ void main() {
       expect(fixture.assertOnlyInstance.staticControl.valid, false);
     });
   });
+
+  group('PatternValidator', () {
+    NgTestFixture<DynamicPatternComponent> fixture;
+
+    setUp(() async {
+      var testBed =
+      NgTestBed.forComponent(ng.DynamicPatternComponentNgFactory);
+      fixture = await testBed.create();
+    });
+
+    tearDown(() => disposeAnyRunningTest());
+
+    Future<void> updateRequired({String pattern}) async {
+      await fixture.update((cmp) => cmp.pattern = pattern);
+      // We have to do this in a separate turn, so that new required value has
+      // propagated.
+      await fixture
+          .update((cmp) => cmp.dynamicControl.control.updateValueAndValidity());
+    }
+
+    bool dynamicControlValid() =>
+        fixture.assertOnlyInstance.dynamicControl.valid;
+
+    test('can be triggered dynamically', () async {
+      expect(dynamicControlValid(), true);
+
+      await updateRequired(pattern: '[A-Za-z]*');
+
+      expect(dynamicControlValid(), true);
+
+      await fixture.update((cmp) => cmp.value = 'abc');
+
+      expect(dynamicControlValid(), true);
+
+      await updateRequired(pattern: '[a-z]*');
+
+      expect(dynamicControlValid(), true);
+
+      await fixture.update((cmp) => cmp.value = '123');
+
+      expect(dynamicControlValid(), false);
+    });
+
+    test('can be set statically', () {
+      expect(fixture.assertOnlyInstance.staticControl.valid, true);
+    });
+  });
 }
 
 @Component(
@@ -78,6 +125,35 @@ void main() {
 class DynamicRequiredComponent {
   String value = '';
   bool required = false;
+
+  @ViewChild('dynamicControl')
+  NgControl dynamicControl;
+
+  @ViewChild('staticControl')
+  NgControl staticControl;
+}
+
+@Component(
+  selector: 'dynamic-pattern',
+  template: '''
+<form ngForm>
+  <input
+      [(ngModel)]="value"
+      ngControl="dynamic"
+      #dynamicControl="ngForm"
+      [pattern]="pattern" />
+  <input
+      [(ngModel)]="value"
+      ngControl="static"
+      #staticControl="ngForm"
+      pattern="[A-Za-z]" />
+</form>
+''',
+  directives: [formDirectives]
+)
+class DynamicPatternComponent {
+  String value = '';
+  String pattern = '';
 
   @ViewChild('dynamicControl')
   NgControl dynamicControl;


### PR DESCRIPTION
When using `pattern` validator inside a component and passing a dynamic value, this one doesn't works as expected:

```html
<input [pattern]="myPattern" [(ngModel)]="myModel">
```

The expected behaivior should be that `mPattern` value should be passed the the `PatternValidator`, however this does not happens.