### PR TITLE
fix(AST): Parse an identifier with a trailing space.

### DIFF
--- a/_tests/test/regression/880_ngfor_extra_spaces_test.dart
+++ b/_tests/test/regression/880_ngfor_extra_spaces_test.dart
@@ -1,0 +1,28 @@
+@TestOn('browser')
+import 'package:angular/angular.dart';
+import 'package:angular_test/angular_test.dart';
+import 'package:test/test.dart';
+
+import '880_ngfor_extra_spaces_test.template.dart' as ng;
+
+// See https://github.com/dart-lang/angular/issues/880.
+void main() {
+  tearDown(disposeAnyRunningTest);
+
+  test('should ignore extra spaces after a let assignment', () async {
+    final fixture = await NgTestBed.forComponent(
+      ng.LetAssignmentSpacingTestNgFactory,
+    ).create();
+    expect(fixture.text, '012');
+  });
+}
+
+@Component(
+    selector: 'let-assignment-spacing-test', directives: [NgFor], template: r'''
+    <ng-container *ngFor="let item of items; let i = index">
+      {{i}}
+    </ng-container>
+  ''')
+class LetAssignmentSpacingTest {
+  final items = [1, 2, 3];
+}

--- a/angular_ast/lib/src/expression/micro/parser.dart
+++ b/angular_ast/lib/src/expression/micro/parser.dart
@@ -118,8 +118,11 @@ class _RecursiveMicroAstParser {
       return;
     }
     if (_tokens.current.type == NgMicroTokenType.letAssignment) {
-      letBindings
-          .add(LetBindingAst.from(_origin, identifier, _tokens.current.lexeme));
+      letBindings.add(LetBindingAst.from(
+        _origin,
+        identifier,
+        _tokens.current.lexeme.trimRight(),
+      ));
     } else {
       letBindings.add(LetBindingAst.from(_origin, identifier));
       if (_tokens.current.type != NgMicroTokenType.bindIdentifier) {

--- a/angular_ast/test/expression/micro/parser_test.dart
+++ b/angular_ast/test/expression/micro/parser_test.dart
@@ -55,6 +55,19 @@ void main() {
     );
   });
 
+  test('should parse a simple let and a let assignment with extra spaces', () {
+    expect(
+      parse('ngThing', 'let baz; let foo = bar ', 0),
+      NgMicroAst(
+        letBindings: [
+          LetBindingAst('baz'),
+          LetBindingAst('foo', 'bar'),
+        ],
+        properties: [],
+      ),
+    );
+  });
+
   test('should parse a let with a full Dart expression', () {
     expect(
       parse('ngFor', 'let x of items.where(filter)', 0),


### PR DESCRIPTION
Closes https://github.com/dart-lang/angular/issues/880.