### PR TITLE
fix(Compiler): Better errors for `@GenerateInjector`.

### DIFF
--- a/angular/CHANGELOG.md
+++ b/angular/CHANGELOG.md
@@ -49,11 +49,16 @@
     caused the directive to no longer be functional
     (`*ngFor="let x; let i = $index "`, for example).
 
+*   [#1570][]: When a provider's `token` for `@GeneratedInjector(...)` is read
+    as `null` (either intentionally, or due to analysis errors/imports missing)
+    a better error message is now thrown with the context of the error.
+
 [#880]: https://github.com/dart-lang/angular/issues/880
 [#1538]: https://github.com/dart-lang/angular/issues/1538
 [#1539]: https://github.com/dart-lang/angular/issues/1539
 [#1540]: https://github.com/dart-lang/angular/issues/1540
 [#1558]: https://github.com/dart-lang/angular/issues/1558
+[#1570]: https://github.com/dart-lang/angular/issues/1570
 
 ### Other improvements
 

--- a/angular_compiler/CHANGELOG.md
+++ b/angular_compiler/CHANGELOG.md
@@ -1,3 +1,5 @@
+*   Catches an (invalid) `null` token of a provider and throws a better error.
+
 ## 0.4.0
 
 ### New Features

--- a/angular_compiler/lib/src/analyzer/di/providers.dart
+++ b/angular_compiler/lib/src/analyzer/di/providers.dart
@@ -48,9 +48,11 @@ class ProviderReader {
 
   ProviderElement _parseProvider(DartObject o) {
     final reader = ConstantReader(o);
-    final token = _tokenReader.parseTokenObject(
-      reader.read('token').objectValue,
-    );
+    final value = reader.read('token');
+    if (value.isNull) {
+      throw new NullTokenException(o);
+    }
+    final token = _tokenReader.parseTokenObject(value.objectValue);
     final useClass = reader.read('useClass');
     if (!useClass.isNull) {
       return _parseUseClass(token, o, useClass.typeValue.element);
@@ -327,4 +329,12 @@ class UseValueProviderElement extends ProviderElement {
     this.useValue, {
     bool multi = false,
   }) : super._(e, providerType, multi);
+}
+
+/// Thrown when a value of `null` is read for a provider token.
+class NullTokenException implements Exception {
+  /// Constant whose `.token` property was resolved to `null`.
+  final DartObject constant;
+
+  const NullTokenException(this.constant);
 }


### PR DESCRIPTION
Closes https://github.com/dart-lang/angular/issues/1570.

A test is prohibitively hard to write (and we already don't have one for the other `null` case).