### PR TITLE
use the latest build and build_runner

### DIFF
--- a/_benchmarks/pubspec.yaml
+++ b/_benchmarks/pubspec.yaml
@@ -13,7 +13,7 @@ dev_dependencies:
   angular_test:
 
   # Actual valid dependencies required.
-  build_runner: ^0.10.0
+  build_runner: ^1.0.0
   build_test: ^0.10.2+5
   build_web_compilers: ^0.4.0+4
   test: ^1.3.0

--- a/_goldens/pubspec.yaml
+++ b/_goldens/pubspec.yaml
@@ -13,7 +13,7 @@ dev_dependencies:
   angular_forms:
 
   # Actual valid dependencies required.
-  build_runner: ^0.10.0
+  build_runner: ^1.0.0
   build_test: ^0.10.2+5
   dart_style: ^1.0.9
   meta: ^1.1.4

--- a/_tests/pubspec.yaml
+++ b/_tests/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
 
   # Actual valid dependencies required.
   analyzer: ^0.32.0
-  build_runner: ^0.10.0
+  build_runner: ^1.0.0
   build_test: ^0.10.2+5
   build_web_compilers: ^0.4.0+4
   mockito: ^3.0.0

--- a/angular/pubspec.yaml
+++ b/angular/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   angular_compiler: 0.4.0
   ##########################################################################
 
-  build: ^0.12.7
+  build: '>=0.12.7 <2.0.0'
   build_config: '>=0.2.6 <0.4.0' # Runtime dependency with no import
   code_builder: '^3.0.1'
   csslib: ^0.14.5

--- a/angular_ast/pubspec.yaml
+++ b/angular_ast/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   source_span: ^1.4.0
 
 dev_dependencies:
-  build_runner: ^0.10.0
+  build_runner: ^1.0.0
   build_test: ^0.10.2+5
   path: ^1.6.1
   test: ^1.3.0

--- a/angular_compiler/pubspec.yaml
+++ b/angular_compiler/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   analyzer: '>=0.32.4 <0.33.0'
   args: ^1.3.0
-  build: ^0.12.7
+  build: '>=0.12.7 <2.0.0'
   code_builder: ^3.0.1
   collection: ^1.14.5
   dart_style: ^1.0.9
@@ -25,7 +25,7 @@ dev_dependencies:
   # This is here in order for it to be resolvable by the analyzer.
   # It is overrode in `dependency_overrides`.
   angular:
-  build_runner: ^0.10.0
+  build_runner: ^1.0.0
   build_test: ^0.10.2+5
   test: ^1.3.0
 

--- a/angular_forms/pubspec.yaml
+++ b/angular_forms/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
 dev_dependencies:
   angular_test: ^2.0.0
-  build_runner: ^0.10.0
+  build_runner: ^1.0.0
   build_test: ^0.10.2+5
   build_web_compilers: ^0.4.0+4
   mockito: ^3.0.0

--- a/angular_router/pubspec.yaml
+++ b/angular_router/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   async: ^2.0.3
   angular_test: ^2.0.0
-  build_runner: ^0.10.0
+  build_runner: ^1.0.0
   build_test: ^0.10.2+5
   build_web_compilers: ^0.4.0+4
   mockito: ^3.0.0-alpha

--- a/angular_test/pubspec.yaml
+++ b/angular_test/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   meta: ^1.1.4
 
 dev_dependencies:
-  build_runner: ^0.10.0
+  build_runner: ^1.0.0
   build_test: ^0.10.2+5
   build_web_compilers: ^0.4.0+4
   test: ^1.3.0


### PR DESCRIPTION
could not update the examples yet because angular_components needs to support package:build 1.x first