### PR TITLE
Rename OnDeactivate's parameters

### DIFF
--- a/angular_router/lib/src/lifecycle.dart
+++ b/angular_router/lib/src/lifecycle.dart
@@ -186,5 +186,5 @@ abstract class OnDeactivate {
   ///
   /// **NOTE**: This is still called even if the component also extends
   /// [CanReuse] and is reused.
-  void onDeactivate(RouterState previous, RouterState current);
+  void onDeactivate(RouterState current, RouterState next);
 }


### PR DESCRIPTION
"previous" and "current" are very confusing names for this method, especially because they mean different things to OnActivate's previous and current. Using "current" and "next" instead makes it clearer that the first argument is for the current Component's RouterState and "next" is for the next component.

This also matches the code in router_impl where _activeState and nextState are passed to onDeactivate.