### PR TITLE
Fix async pipe losing stacktrace on exception

### DIFF
--- a/angular/lib/src/common/pipes/async_pipe.dart
+++ b/angular/lib/src/common/pipes/async_pipe.dart
@@ -8,7 +8,7 @@ import 'invalid_pipe_argument_exception.dart' show InvalidPipeArgumentException;
 class _ObservableStrategy {
   StreamSubscription<Object> createSubscription(
       Stream<Object> stream, void updateLatestValue(value)) {
-    return stream.listen(updateLatestValue, onError: (e) => throw e);
+    return stream.listen(updateLatestValue);
   }
 
   void dispose(StreamSubscription<Object> subscription) {


### PR DESCRIPTION
Rethrowing exception from a stream does not keep the stacktrace of the exception.